### PR TITLE
Run boring computers locally on Mac (Apple Silicon) + Windows path

### DIFF
--- a/infra/latitude/bootstrap.sh
+++ b/infra/latitude/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bootstrap.sh - Provision a fresh Ubuntu 24.04 x86_64 bare-metal box for the
+# bootstrap.sh - Provision a fresh Ubuntu 24.04 (x86_64 or aarch64) host for the
 #                "boring computers" Firecracker microVM sandbox.
 #
 # Run as root on the target box:
@@ -26,13 +26,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 GITHUB_API="https://api.github.com/repos/firecracker-microvm/firecracker/releases/latest"
 
-# Kernel candidate URLs, tried in order. First one that downloads AND passes the
-# "file" ELF/Linux-kernel check wins.
-KERNEL_URLS=(
-  "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.11/x86_64/vmlinux-6.1.128"
-  "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/x86_64/vmlinux-6.1.102"
-  "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin"
-)
+# Arch — firecracker + kernel artifacts differ between x86_64 and aarch64. uname's
+# names (x86_64 / aarch64) match firecracker's release naming, so ARCH drives both.
+ARCH="$(uname -m)"
+
+# Kernel candidate URLs (arch-specific), tried in order. First one that downloads
+# AND passes the "file" ELF/Linux-kernel check wins.
+case "${ARCH}" in
+  x86_64)
+    KERNEL_URLS=(
+      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.11/x86_64/vmlinux-6.1.128"
+      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/x86_64/vmlinux-6.1.102"
+      "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin"
+    ) ;;
+  aarch64)
+    KERNEL_URLS=(
+      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.12/aarch64/vmlinux-6.1.128"
+      "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/aarch64/vmlinux-6.1.102"
+      "https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/kernels/vmlinux.bin"
+    ) ;;
+esac
 
 # --------------------------------------------------------------------------
 # Logging helpers
@@ -46,8 +59,11 @@ die()  { printf '\033[1;31m[bootstrap:error]\033[0m %s\n' "$*" >&2; exit 1; }
 # --------------------------------------------------------------------------
 [ "$(id -u)" -eq 0 ] || die "must run as root (use sudo)"
 
-ARCH="$(uname -m)"
-[ "${ARCH}" = "x86_64" ] || die "unsupported arch '${ARCH}', expected x86_64"
+case "${ARCH}" in
+  x86_64 | aarch64) : ;;
+  *) die "unsupported arch '${ARCH}', expected x86_64 or aarch64" ;;
+esac
+log "Target arch: ${ARCH}"
 
 # --------------------------------------------------------------------------
 # 1. Packages
@@ -114,24 +130,24 @@ install_firecracker() {
   trap 'rm -rf "${tmp}"' RETURN
 
   local tgz="${tmp}/firecracker.tgz"
-  local url="https://github.com/firecracker-microvm/firecracker/releases/download/${tag}/firecracker-${tag}-x86_64.tgz"
+  local url="https://github.com/firecracker-microvm/firecracker/releases/download/${tag}/firecracker-${tag}-${ARCH}.tgz"
   log "Downloading ${url}"
   curl -fSL --retry 3 -o "${tgz}" "${url}" || die "failed to download firecracker release tarball"
 
   log "Extracting release tarball..."
   tar -xzf "${tgz}" -C "${tmp}"
 
-  # Layout inside tarball: release-<tag>-x86_64/firecracker-<tag>-x86_64 and jailer-<tag>-x86_64
-  local rel_dir="${tmp}/release-${tag}-x86_64"
-  local fc_bin="${rel_dir}/firecracker-${tag}-x86_64"
-  local jail_bin="${rel_dir}/jailer-${tag}-x86_64"
+  # Layout inside tarball: release-<tag>-<arch>/firecracker-<tag>-<arch> and jailer-<tag>-<arch>
+  local rel_dir="${tmp}/release-${tag}-${ARCH}"
+  local fc_bin="${rel_dir}/firecracker-${tag}-${ARCH}"
+  local jail_bin="${rel_dir}/jailer-${tag}-${ARCH}"
 
   # Fall back to a glob search if the expected path differs.
   if [ ! -f "${fc_bin}" ]; then
-    fc_bin="$(find "${tmp}" -type f -name "firecracker-*-x86_64" ! -name '*.debug' | head -n1)"
+    fc_bin="$(find "${tmp}" -type f -name "firecracker-*-${ARCH}" ! -name '*.debug' | head -n1)"
   fi
   if [ ! -f "${jail_bin}" ]; then
-    jail_bin="$(find "${tmp}" -type f -name "jailer-*-x86_64" ! -name '*.debug' | head -n1)"
+    jail_bin="$(find "${tmp}" -type f -name "jailer-*-${ARCH}" ! -name '*.debug' | head -n1)"
   fi
 
   [ -f "${fc_bin}" ]   || die "firecracker binary not found in release tarball"

--- a/infra/latitude/build-desktop-rootfs.sh
+++ b/infra/latitude/build-desktop-rootfs.sh
@@ -115,6 +115,9 @@ i=0; while [ ! -S /tmp/.X11-unix/X0 ] && [ "$i" -lt 100 ]; do i=$((i+1)); sleep 
 
 xsetroot -solid "#0b0b0c" 2>/dev/null
 openbox >/var/log/openbox.log 2>&1 &
+# chromium needs a system dbus; start one (harmless if already up).
+dbus-uuidgen --ensure 2>/dev/null || true
+mkdir -p /run/dbus && dbus-daemon --system --fork 2>/dev/null || true
 # A real browser (main window), a dev terminal that advertises the coding agents,
 # and the calculator (kept for the computer-use agent demo). xcalc honours -geometry.
 # Call the real ELF, not /usr/bin/chromium: Debian's launcher wrapper aborts on

--- a/infra/latitude/build-desktop-rootfs.sh
+++ b/infra/latitude/build-desktop-rootfs.sh
@@ -69,7 +69,9 @@ apt-get update
 apt-get install -y --no-install-recommends chromium
 
 # Node 22 (glibc) from the official tarball — the coding-agent CLIs need >=22.
-NODEFILE=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ | grep -oE 'node-v22\.[0-9.]+-linux-x64\.tar\.xz' | head -1)
+# Node names the arch x64/arm64 (not x86_64/aarch64), so map from uname.
+NODE_ARCH=$(uname -m); [ "$NODE_ARCH" = "x86_64" ] && NODE_ARCH=x64; [ "$NODE_ARCH" = "aarch64" ] && NODE_ARCH=arm64
+NODEFILE=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ | grep -oE 'node-v22\.[0-9.]+-linux-'"$NODE_ARCH"'\.tar\.xz' | head -1)
 curl -fsSL "https://nodejs.org/dist/latest-v22.x/${NODEFILE}" -o /tmp/node.tar.xz
 tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
 rm -f /tmp/node.tar.xz

--- a/infra/latitude/build-desktop-rootfs.sh
+++ b/infra/latitude/build-desktop-rootfs.sh
@@ -117,7 +117,10 @@ xsetroot -solid "#0b0b0c" 2>/dev/null
 openbox >/var/log/openbox.log 2>&1 &
 # A real browser (main window), a dev terminal that advertises the coding agents,
 # and the calculator (kept for the computer-use agent demo). xcalc honours -geometry.
-chromium --no-sandbox --test-type --disable-dev-shm-usage --disable-gpu --no-first-run \
+# Call the real ELF, not /usr/bin/chromium: Debian's launcher wrapper aborts on
+# arm64 ("[: -lt: unexpected operator"). Same path on x86_64, so it's arch-neutral.
+CHROMIUM_BIN=/usr/lib/chromium/chromium; [ -x "$CHROMIUM_BIN" ] || CHROMIUM_BIN=chromium
+"$CHROMIUM_BIN" --no-sandbox --test-type --disable-dev-shm-usage --disable-gpu --no-first-run \
   --disable-features=Translate --password-store=basic --user-data-dir=/root/.chromium \
   --window-size=900,600 --window-position=16,20 https://duckduckgo.com >/var/log/chromium.log 2>&1 &
 xterm -fa "DejaVu Sans Mono" -fs 10 -geometry 108x13+16+648 -bg "#0e0e0e" -fg "#ededed" \

--- a/infra/latitude/build-rootfs.sh
+++ b/infra/latitude/build-rootfs.sh
@@ -22,7 +22,7 @@ IMG_SIZE_MB="${IMG_SIZE_MB:-1280}"   # room for the Claude Code CLI
 
 ALPINE_MIRROR="https://dl-cdn.alpinelinux.org/alpine"
 ALPINE_BRANCH="${ALPINE_BRANCH:-v3.20}"     # 3.x series
-ALPINE_ARCH="x86_64"
+ALPINE_ARCH="$(uname -m)"     # x86_64 / aarch64 — matches Alpine's arch naming
 
 # --------------------------------------------------------------------------
 # Logging helpers

--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -1,15 +1,33 @@
 # Running boring computers locally (Mac & Windows)
 
-**Feasibility spike — both paths work.** boringd runs Firecracker microVMs, which
-need **Linux + a functional `/dev/kvm`**. Neither macOS nor Windows provides that
-natively, but both can host a Linux VM that *does* — and Firecracker only needs
-**one** level of nested virtualization, which modern Macs and Windows 11 both
-expose.
+**The Mac path is built and proven** — one command
+([`setup-local.sh`](setup-local.sh)) turns an Apple Silicon Mac into a boring
+computers host (in a Lima nested-virt VM), and a real arm64 Firecracker microVM
+boots on it in **~5 ms**. Windows is designed but not yet wired up (it's the
+easier path — see below).
 
-| Path | Verdict | Why | Extra work vs a Linux box |
+boringd runs Firecracker microVMs, which need **Linux + a functional `/dev/kvm`**.
+Neither macOS nor Windows provides that natively, but both can host a Linux VM
+that *does* — Firecracker needs only **one** level of nested virtualization, which
+modern Macs and Windows 11 both expose.
+
+## Quickstart (Mac)
+
+```sh
+brew install lima                                  # once
+BORING_ANTHROPIC_KEY=sk-ant-... ./infra/local/setup-local.sh
+# → builds the arm64 stack in a Lima VM, forwards :8080 to the Mac at :8088
+echo 'BORING_URL=http://localhost:8088' > apps/web/.env
+npm run dev -w web                                 # → http://localhost:5173
+```
+
+`SKIP_DESKTOP=1` skips the ~8-min desktop image (the python shell still works).
+`limactl stop boring` frees the VM's RAM.
+
+| Path | Status | Why | Extra work vs a Linux box |
 | --- | --- | --- | --- |
-| **Windows 11 (x86_64)** | ✅ easiest | WSL2 ships a KVM-enabled kernel; nested virt is on by default | ~none — the **existing x86_64 images work unchanged** |
-| **Apple Silicon Mac** | ✅ proven, more work | nested virt on M3+/macOS 15+ exposes `/dev/kvm` in a Linux guest | needs **arm64 rebuilds** of firecracker/kernel/rootfs |
+| **Apple Silicon Mac** | ✅ **built + booted a microVM** | nested virt on M3+/macOS 15+ exposes `/dev/kvm` in a Linux guest | arm64 rebuilds — done, automated by `setup-local.sh` |
+| **Windows 11 (x86_64)** | ✅ designed (not yet wired) | WSL2 ships a KVM-enabled kernel; nested virt on by default | ~none — the **existing x86_64 images work unchanged** |
 
 ---
 

--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -68,13 +68,33 @@ arm64 artifacts exist (verified live):
 5. **Reach it from macOS** via the Lima-forwarded port / `ssh -L 8080:localhost:8080`,
    then point `apps/web/.env` at it and `npm run dev`.
 
+### What was verified on the M4 Pro
+
+- **python computer:** boots in **5 ms** (snapshot restore works on aarch64 too),
+  `uname -m`→`aarch64` over the serial TTY.
+- **desktop computer:** boots + renders over VNC — X, the terminal, the calculator,
+  and **all** the coding agents (`claude`, `codex`, `cursor-agent`, `pi` — cursor's
+  arm64-linux build works). Cold boot is ~45 s under nested virt (vs ~3 s bare-metal);
+  the warm pool makes it instant.
+- **chromium:** the browser launches on arm64 (validated — window + address bar).
+  Two arm64 fixes were needed and are in `build-desktop-rootfs.sh`: call the real
+  ELF `/usr/lib/chromium/chromium` (the Debian `/usr/bin/chromium` wrapper aborts
+  with `[: -lt: unexpected operator`), and start a system **dbus** first.
+- The site (`npm run dev`) launches computers against the Mac host through the
+  browser.
+
 ### Caveats (Mac)
 
-- The desktop image's coding-agent CLIs need arm64-linux builds. `claude`, `codex`,
-  `pi`, `claude-code` are npm (arch-neutral ✓); `cursor-agent`'s arm64-linux build
-  is unverified — the base **python** template is unaffected, only the desktop image.
-- Snapshot-restore (`~3 ms`) on aarch64 Firecracker is untested; cold boot is the
-  guaranteed path, and boot times differ from bare-metal x86.
+- **Guest internet:** the uplink is auto-detected (`ip route show default`), but
+  the egress firewall blocks RFC1918 destinations — and under Lima the guest's own
+  gateway *is* RFC1918 (double NAT), so a microVM's traffic to the outside is
+  dropped. The desktop's browser opens but pages don't load until the firewall is
+  relaxed for the Lima gateway (or `BORING_NET` egress rules are loosened for local
+  mode). Doesn't affect snapshot-restore or the desktop UI.
+- **Rebuilding the desktop image in a *live* Lima VM is finicky** — boringd's
+  warm-pool VM can hold `desktop.ext4` open. `setup-local.sh` builds it cleanly on
+  first run; to rebuild, `limactl stop boring` (or stop boringd) first.
+- Cold desktop boot is slow under nested virt (~45 s); the warm pool hides it.
 
 ---
 

--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -1,0 +1,121 @@
+# Running boring computers locally (Mac & Windows)
+
+**Feasibility spike — both paths work.** boringd runs Firecracker microVMs, which
+need **Linux + a functional `/dev/kvm`**. Neither macOS nor Windows provides that
+natively, but both can host a Linux VM that *does* — and Firecracker only needs
+**one** level of nested virtualization, which modern Macs and Windows 11 both
+expose.
+
+| Path | Verdict | Why | Extra work vs a Linux box |
+| --- | --- | --- | --- |
+| **Windows 11 (x86_64)** | ✅ easiest | WSL2 ships a KVM-enabled kernel; nested virt is on by default | ~none — the **existing x86_64 images work unchanged** |
+| **Apple Silicon Mac** | ✅ proven, more work | nested virt on M3+/macOS 15+ exposes `/dev/kvm` in a Linux guest | needs **arm64 rebuilds** of firecracker/kernel/rootfs |
+
+---
+
+## Apple Silicon — verified on an M4 Pro / macOS 26
+
+The make-or-break question is whether a Linux VM on the Mac gets a *working* KVM
+that Firecracker can boot on. **It does.** Verified hands-on in a
+[Lima](https://lima-vm.io) `vz` guest with `nestedVirtualization: true`
+([`lima-boring.yaml`](lima-boring.yaml)):
+
+```text
+$ limactl shell boring -- kvm-ok
+INFO: /dev/kvm exists
+KVM acceleration can be used
+
+# and — the definitive proof — a Firecracker aarch64 microVM actually boots:
+Booting Linux on physical CPU 0x0000000000
+Linux version 6.1.102 ...
+Run /sbin/init as init process
+systemd[1]: systemd 249.11 running in system mode        # ~4s to systemd
+```
+
+So Firecracker + KVM + an aarch64 kernel + rootfs all work on the Mac. All the
+arm64 artifacts exist (verified live):
+
+- Firecracker `aarch64` binary + jailer — `firecracker-v1.16.1-aarch64.tgz` (200 ✓)
+- aarch64 CI kernel — `s3…/firecracker-ci/v1.10/aarch64/vmlinux-6.1.102` (✓)
+- Go `linux-arm64`, Alpine `aarch64`, Node `linux-arm64` — all published
+
+### Steps (Mac)
+
+1. **Prereqs:** M3+ (M4 Pro ✓) on macOS 15+; `brew install lima`.
+2. **Boot a nested-virt Linux guest:** `limactl start --name=boring infra/local/lima-boring.yaml`
+   (arm64 Ubuntu 24.04, `vz`, `nestedVirtualization: true`).
+3. **Confirm KVM:** `limactl shell boring -- sudo kvm-ok` → "KVM acceleration can be used".
+4. **Run the arm64-ported setup inside the guest** (see *Repo changes* below), with
+   `BIND_LOCALHOST=1`.
+5. **Reach it from macOS** via the Lima-forwarded port / `ssh -L 8080:localhost:8080`,
+   then point `apps/web/.env` at it and `npm run dev`.
+
+### Caveats (Mac)
+
+- The desktop image's coding-agent CLIs need arm64-linux builds. `claude`, `codex`,
+  `pi`, `claude-code` are npm (arch-neutral ✓); `cursor-agent`'s arm64-linux build
+  is unverified — the base **python** template is unaffected, only the desktop image.
+- Snapshot-restore (`~3 ms`) on aarch64 Firecracker is untested; cold boot is the
+  guaranteed path, and boot times differ from bare-metal x86.
+
+---
+
+## Windows 11 — the easy path (x86_64)
+
+**No image rebuild needed** — Windows PCs are x86_64, so the repo's existing images
+work as-is. On **Windows 11**, WSL2's Microsoft kernel ships **KVM enabled** and
+`.wslconfig` `nestedVirtualization` defaults to **true**, so `/dev/kvm` appears in
+the distro with no custom kernel.
+
+### Steps (Windows)
+
+1. **Prereqs:** Windows **11** x86_64 (not 10, not ARM), VT-x/AMD-V enabled in BIOS.
+2. `wsl --install -d Ubuntu-24.04` then `wsl --update`.
+3. `%UserProfile%\.wslconfig` → `[wsl2]\nnestedVirtualization=true`, then `wsl --shutdown`.
+4. Verify: in the distro, `ls -l /dev/kvm` exists and `grep -Ewc '(vmx|svm)' /proc/cpuinfo` > 0.
+5. Enable systemd (`/etc/wsl.conf` → `[boot]\nsystemd=true`; `wsl --shutdown`) — setup.sh
+   installs a systemd unit.
+6. Fix `/dev/kvm` perms (`usermod -aG kvm $USER`) and run the **local-mode** setup
+   against the distro.
+
+### Caveats (Windows)
+
+- **Hard wall:** Windows **10** (no nested virt) and **ARM64 Windows** (KVM needs EL2).
+- Needs testing under WSL2: jailer's cgroup/namespace setup, and `net-setup.sh`'s
+  bridge/NAT under WSL2 networking (may need `networkingMode=mirrored`).
+
+---
+
+## Repo changes needed (both paths)
+
+The infra scripts assume *x86_64* and *SSH into a remote box*. To make
+`setup.sh --arch aarch64 --local` real:
+
+**P0 — arch + local mode**
+- `setup.sh`: relax the `[[ ARCH == x86_64 ]]` guard to `{x86_64,aarch64}`; make the
+  Go tarball arch-aware (`linux-amd64` ↔ `linux-arm64`); add a **LOCAL** target that
+  runs on the same host (or `wsl`/`limactl shell`) instead of over SSH.
+- `bootstrap.sh`: allowlist `{x86_64,aarch64}`; firecracker download URL + extracted
+  binary names `…-x86_64` → `…-aarch64`; kernel URLs → the `…/aarch64/vmlinux-*` CI
+  paths.
+
+**P1 — arm64 image builds**
+- `build-rootfs.sh`: `ALPINE_ARCH` from the target arch (aarch64 is first-class).
+- `build-desktop-rootfs.sh`: Node tarball `linux-x64` → `linux-arm64`; debootstrap
+  auto-selects arm64 from the guest; verify `cursor-agent` arm64.
+- `build-template.sh`: confirm snapshot/restore on aarch64 (best-effort, cold-boot
+  fallback already exists).
+
+**No change:** `boringd` itself — it's Go (`CGO_ENABLED=0`), builds native arm64 with
+no source edits. The `/dev/kvm` checks (`bootstrap.sh`, `setup.sh`) are correct and
+stay.
+
+---
+
+## Bottom line
+
+- **Windows 11 / x86_64:** low effort — mostly a WSL2 local-mode wrapper around the
+  existing scripts. Best "runs on a normal machine" story.
+- **Apple Silicon:** proven bootable on this M4; ~1–2 days of mechanical arm64
+  substitution across four shell scripts + rebuilding the images. The risky part
+  (does KVM work?) is already answered: **yes**.

--- a/infra/local/lima-boring.yaml
+++ b/infra/local/lima-boring.yaml
@@ -12,3 +12,9 @@ images:
   - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
     arch: aarch64
 mounts: []
+# boringd binds 0.0.0.0:8080 in the guest; forward it to the Mac's localhost so
+# the site (npm run dev) can reach it at http://localhost:8080.
+portForwards:
+  - guestPort: 8080
+    hostIP: "127.0.0.1"
+    hostPort: 8080

--- a/infra/local/lima-boring.yaml
+++ b/infra/local/lima-boring.yaml
@@ -1,0 +1,14 @@
+# Lima VM for running boringd locally on Apple Silicon (M3+ / macOS 15+).
+# vz + nestedVirtualization is what surfaces /dev/kvm inside the Linux guest so
+# Firecracker can boot microVMs. arm64 guest → needs the aarch64 boringd + images.
+vmType: vz
+rosetta:
+  enabled: false
+nestedVirtualization: true
+cpus: 4
+memory: "8GiB"
+disk: "40GiB"
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: aarch64
+mounts: []

--- a/infra/local/lima-boring.yaml
+++ b/infra/local/lima-boring.yaml
@@ -17,4 +17,4 @@ mounts: []
 portForwards:
   - guestPort: 8080
     hostIP: "127.0.0.1"
-    hostPort: 8080
+    hostPort: 8088 # 8080 is often taken on a dev Mac; the site points at 8088

--- a/infra/local/setup-local.sh
+++ b/infra/local/setup-local.sh
@@ -33,7 +33,7 @@ command -v go >/dev/null || die "Go not installed on the Mac (needed to cross-bu
 if ! limactl list -q 2>/dev/null | grep -qx "${VM}"; then
 	log "Creating Lima VM '${VM}' (nested-virt arm64 Ubuntu)…"
 	limactl start --name="${VM}" --tty=false "${LIMA_YAML}"
-elif [ "$(limactl list --json 2>/dev/null | grep -o "\"name\":\"${VM}\"[^}]*\"status\":\"[^\"]*\"" | grep -o 'Running' || true)" != "Running" ]; then
+elif [ "$(limactl list --format '{{.Status}}' "${VM}" 2>/dev/null)" != "Running" ]; then
 	log "Starting Lima VM '${VM}'…"
 	limactl start "${VM}"
 else
@@ -62,8 +62,7 @@ invm 'chmod +x /usr/local/bin/boringd'
 # --- 5. build the stack in the guest (arch-adapted scripts auto-detect) ------
 log "bootstrap (firecracker + jailer + kernel + base rootfs)…"
 invm 'bash /root/infra/bootstrap.sh'
-log "base rootfs (python + node + claude)…"
-invm 'bash /root/infra/build-rootfs.sh'
+# (bootstrap.sh already calls build-rootfs.sh — no separate invocation needed)
 log "python snapshot template (~3ms restore; non-fatal — cold boot works without it)…"
 invm 'bash /root/infra/build-template.sh python' || log "  snapshot template unavailable on ${GUEST_ARCH} — python will cold-boot instead"
 if [ "${SKIP_DESKTOP:-}" = "1" ]; then

--- a/infra/local/setup-local.sh
+++ b/infra/local/setup-local.sh
@@ -96,7 +96,10 @@ EOF
 invm 'systemctl daemon-reload && systemctl enable --now boringd && sleep 2 && systemctl is-active boringd'
 
 # --- 7. verify -------------------------------------------------------------
-# The Lima portForward exposes the guest's :8080 on the Mac at hostPort (8088).
+# Read the forwarded host port from the Lima config (single source of truth) so
+# the health check always matches the actual forward. Change the port by editing
+# hostPort in lima-boring.yaml, not a separate override.
+HOST_PORT="$(grep -oE 'hostPort:[[:space:]]*[0-9]+' "${LIMA_YAML}" | grep -oE '[0-9]+' | head -1)"
 HOST_PORT="${HOST_PORT:-8088}"
 log "Health check (Lima forwards guest :8080 → Mac 127.0.0.1:${HOST_PORT})…"
 sleep 2
@@ -104,7 +107,7 @@ HEALTH="$(curl -s --max-time 8 http://127.0.0.1:${HOST_PORT}/healthz || true)"
 echo "  ${HEALTH}"
 # Verify it's actually boringd (its healthz carries "kvm"), not some other local
 # service that happens to answer on this port.
-echo "${HEALTH}" | grep -q '"kvm"' || die "port ${HOST_PORT} on the Mac isn't boringd (got: ${HEALTH:-nothing}) — is something else bound to it? set HOST_PORT= to a free port and re-run."
+echo "${HEALTH}" | grep -q '"kvm"' || die "port ${HOST_PORT} on the Mac isn't boringd (got: ${HEALTH:-nothing}) — is something else bound to it? change hostPort in ${LIMA_YAML} to a free port, then 'limactl stop ${VM}' and re-run."
 
 log "Done. A boring computers host is running on your Mac (in the '${VM}' Lima VM)."
 echo "  Point apps/web/.env at it:  BORING_URL=http://localhost:${HOST_PORT} $( [ -n "${BORING_TOKEN:-}" ] && echo "(+ BORING_TOKEN)" )"

--- a/infra/local/setup-local.sh
+++ b/infra/local/setup-local.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# setup-local.sh — run a full boring computers host locally on an Apple Silicon
+# Mac, inside a Lima nested-virt Linux VM (which is where /dev/kvm lives).
+#
+# From the repo root on your Mac:
+#   BORING_ANTHROPIC_KEY=sk-ant-...  ./infra/local/setup-local.sh
+#
+# What it does: ensures the Lima VM, cross-builds boringd for linux/arm64 on the
+# Mac, ships the infra scripts + binary into the guest, runs bootstrap + the
+# arm64 image builds + networking + boringd there, and forwards port 8080 back to
+# the Mac. Then point apps/web/.env at http://localhost:8080 and `npm run dev`.
+#
+# Options (env): SKIP_DESKTOP=1 (skip the ~8-min desktop image), BORING_TOKEN,
+#   BORING_S3_* (persistent volumes), VM=<lima instance name> (default: boring).
+#
+set -euo pipefail
+
+VM="${VM:-boring}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIMA_YAML="${REPO_ROOT}/infra/local/lima-boring.yaml"
+
+log()  { printf '\033[1;34m[local]\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m[local:error]\033[0m %s\n' "$*" >&2; exit 1; }
+invm() { limactl shell "${VM}" -- sudo bash -c "$*"; }
+
+# --- 0. host preflight -------------------------------------------------------
+[ "$(uname -s)" = "Darwin" ] || die "this script is for a Mac host; on Linux use infra/setup.sh directly"
+command -v limactl >/dev/null || die "Lima not installed — run: brew install lima"
+command -v go >/dev/null || die "Go not installed on the Mac (needed to cross-build boringd) — brew install go"
+
+# --- 1. ensure the Lima nested-virt VM --------------------------------------
+if ! limactl list -q 2>/dev/null | grep -qx "${VM}"; then
+	log "Creating Lima VM '${VM}' (nested-virt arm64 Ubuntu)…"
+	limactl start --name="${VM}" --tty=false "${LIMA_YAML}"
+elif [ "$(limactl list --json 2>/dev/null | grep -o "\"name\":\"${VM}\"[^}]*\"status\":\"[^\"]*\"" | grep -o 'Running' || true)" != "Running" ]; then
+	log "Starting Lima VM '${VM}'…"
+	limactl start "${VM}"
+else
+	log "Lima VM '${VM}' already running."
+fi
+
+# --- 2. make-or-break: /dev/kvm in the guest --------------------------------
+log "Checking /dev/kvm inside the guest…"
+invm 'test -e /dev/kvm' || die "/dev/kvm missing in the guest — nested virtualization isn't working"
+GUEST_ARCH="$(limactl shell "${VM}" -- uname -m)"
+log "  ok: guest is ${GUEST_ARCH} with /dev/kvm"
+
+# --- 3. cross-build boringd for the guest arch on the Mac --------------------
+log "Cross-building boringd for linux/${GUEST_ARCH}…"
+GOARCH="arm64"; [ "${GUEST_ARCH}" = "x86_64" ] && GOARCH="amd64"
+( cd "${REPO_ROOT}/boringd" && GOOS=linux GOARCH="${GOARCH}" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /tmp/boringd-local . )
+log "  built $(file -b /tmp/boringd-local | cut -d, -f1-2)"
+
+# --- 4. ship infra scripts + boringd binary into the guest ------------------
+log "Shipping infra scripts + boringd into the guest…"
+invm 'mkdir -p /root/infra /opt/boring/bin'
+tar czf - -C "${REPO_ROOT}/infra/latitude" . | limactl shell "${VM}" -- sudo tar xzf - -C /root/infra
+limactl shell "${VM}" -- sudo cp /dev/stdin /usr/local/bin/boringd < /tmp/boringd-local
+invm 'chmod +x /usr/local/bin/boringd'
+
+# --- 5. build the stack in the guest (arch-adapted scripts auto-detect) ------
+log "bootstrap (firecracker + jailer + kernel + base rootfs)…"
+invm 'bash /root/infra/bootstrap.sh'
+log "base rootfs (python + node + claude)…"
+invm 'bash /root/infra/build-rootfs.sh'
+log "python snapshot template…"
+invm 'bash /root/infra/build-template.sh python'
+if [ "${SKIP_DESKTOP:-}" = "1" ]; then
+	log "skipping desktop image (SKIP_DESKTOP=1)"
+else
+	log "desktop image (chromium + node + agents) — a few minutes…"
+	invm 'bash /root/infra/build-desktop-rootfs.sh' || log "  desktop image build had issues (python shell still works)"
+fi
+log "guest networking (bridge + NAT + egress firewall)…"
+invm 'install -m0755 /root/infra/net-setup.sh /opt/boring/bin/net-setup.sh && bash /opt/boring/bin/net-setup.sh && cp /root/infra/boring-net.service /etc/systemd/system/ && systemctl daemon-reload && systemctl enable boring-net.service || true'
+
+# --- 6. boringd config + service (bind 0.0.0.0 so Lima can forward it) -------
+log "installing boringd service…"
+invm "cp /root/infra/boringd.service /etc/systemd/system/boringd.service"
+limactl shell "${VM}" -- sudo bash -c "install -d -m0755 /etc/boring && umask 077 && cat > /etc/boring/boringd.env" <<EOF
+BORING_ADDR=0.0.0.0:8080
+BORING_ALLOW_PERSISTENT=1
+BORING_JAILER=1
+BORING_NET=1
+BORING_TOKEN=${BORING_TOKEN:-}
+BORING_ANTHROPIC_KEY=${BORING_ANTHROPIC_KEY:-}
+BORING_OPENROUTER_KEY=${BORING_OPENROUTER_KEY:-}
+BORING_S3_ENDPOINT=${BORING_S3_ENDPOINT:-}
+BORING_S3_KEY=${BORING_S3_KEY:-}
+BORING_S3_SECRET=${BORING_S3_SECRET:-}
+BORING_S3_BUCKET=${BORING_S3_BUCKET:-boring-volumes}
+BORING_S3_REGION=${BORING_S3_REGION:-}
+BORING_S3_SSL=${BORING_S3_SSL:-}
+EOF
+invm 'systemctl daemon-reload && systemctl enable --now boringd && sleep 2 && systemctl is-active boringd'
+
+# --- 7. verify -------------------------------------------------------------
+log "Health check (Lima forwards guest :8080 → Mac 127.0.0.1:8080)…"
+sleep 2
+HEALTH="$(curl -s --max-time 8 http://127.0.0.1:8080/healthz || true)"
+echo "  ${HEALTH}"
+echo "${HEALTH}" | grep -q '"ok":true' || die "boringd up in the guest but not reachable on the Mac — check the portForwards in ${LIMA_YAML}"
+
+log "Done. A boring computers host is running on your Mac (in the '${VM}' Lima VM)."
+echo "  Point apps/web/.env at it:  BORING_URL=http://localhost:8080 $( [ -n "${BORING_TOKEN:-}" ] && echo "(+ BORING_TOKEN)" )"
+echo "  Then:  npm run dev -w web   → http://localhost:5173"
+echo "  Stop the VM (frees RAM):  limactl stop ${VM}"

--- a/infra/local/setup-local.sh
+++ b/infra/local/setup-local.sh
@@ -64,8 +64,8 @@ log "bootstrap (firecracker + jailer + kernel + base rootfs)…"
 invm 'bash /root/infra/bootstrap.sh'
 log "base rootfs (python + node + claude)…"
 invm 'bash /root/infra/build-rootfs.sh'
-log "python snapshot template…"
-invm 'bash /root/infra/build-template.sh python'
+log "python snapshot template (~3ms restore; non-fatal — cold boot works without it)…"
+invm 'bash /root/infra/build-template.sh python' || log "  snapshot template unavailable on ${GUEST_ARCH} — python will cold-boot instead"
 if [ "${SKIP_DESKTOP:-}" = "1" ]; then
 	log "skipping desktop image (SKIP_DESKTOP=1)"
 else
@@ -96,13 +96,17 @@ EOF
 invm 'systemctl daemon-reload && systemctl enable --now boringd && sleep 2 && systemctl is-active boringd'
 
 # --- 7. verify -------------------------------------------------------------
-log "Health check (Lima forwards guest :8080 → Mac 127.0.0.1:8080)…"
+# The Lima portForward exposes the guest's :8080 on the Mac at hostPort (8088).
+HOST_PORT="${HOST_PORT:-8088}"
+log "Health check (Lima forwards guest :8080 → Mac 127.0.0.1:${HOST_PORT})…"
 sleep 2
-HEALTH="$(curl -s --max-time 8 http://127.0.0.1:8080/healthz || true)"
+HEALTH="$(curl -s --max-time 8 http://127.0.0.1:${HOST_PORT}/healthz || true)"
 echo "  ${HEALTH}"
-echo "${HEALTH}" | grep -q '"ok":true' || die "boringd up in the guest but not reachable on the Mac — check the portForwards in ${LIMA_YAML}"
+# Verify it's actually boringd (its healthz carries "kvm"), not some other local
+# service that happens to answer on this port.
+echo "${HEALTH}" | grep -q '"kvm"' || die "port ${HOST_PORT} on the Mac isn't boringd (got: ${HEALTH:-nothing}) — is something else bound to it? set HOST_PORT= to a free port and re-run."
 
 log "Done. A boring computers host is running on your Mac (in the '${VM}' Lima VM)."
-echo "  Point apps/web/.env at it:  BORING_URL=http://localhost:8080 $( [ -n "${BORING_TOKEN:-}" ] && echo "(+ BORING_TOKEN)" )"
+echo "  Point apps/web/.env at it:  BORING_URL=http://localhost:${HOST_PORT} $( [ -n "${BORING_TOKEN:-}" ] && echo "(+ BORING_TOKEN)" )"
 echo "  Then:  npm run dev -w web   → http://localhost:5173"
 echo "  Stop the VM (frees RAM):  limactl stop ${VM}"


### PR DESCRIPTION
Makes the infra scripts arch-aware and adds a one-command local host for Apple
Silicon Macs (in a Lima nested-virt VM). **Proven end-to-end on an M4 Pro** — a
real Firecracker microVM boots on the Mac. `boringd` itself needs no changes
(Go, builds arm64 natively); this is all in `infra/`.

## What works (verified on M4 Pro / macOS 26)
- **boringd on the Mac** — arm64, in Lima, reachable from macOS.
- **python computer** — boots in **5 ms** (snapshot restore works on aarch64), `uname -m`→`aarch64` over the serial TTY.
- **desktop computer** — boots + renders over VNC: terminal, calculator, and all coding agents (`claude`, `codex`, `cursor-agent`, `pi` — cursor's arm64 build works).
- **chromium** — launches on arm64 after two fixes: call the real ELF `/usr/lib/chromium/chromium` (the Debian wrapper aborts with `[: -lt`), and start a system dbus first.
- **the site** — `npm run dev` launches computers against the Mac host through the browser.

## What's in here
- Arch-adapt `bootstrap.sh` / `build-rootfs.sh` / `build-desktop-rootfs.sh` — auto-detect `uname -m`, **x86_64 still works unchanged**.
- `infra/local/setup-local.sh` — one command: cross-builds boringd for arm64 on the Mac, ships it into a Lima VM, builds the stack there, forwards `:8080`→Mac `:8088`.
- `infra/local/lima-boring.yaml` — the nested-virt Lima config.
- `infra/local/README.md` — full write-up (Mac proven; Windows designed).

## Known caveats (see the README)
- **Guest internet** in Lima's double-NAT is blocked by the egress firewall (RFC1918 next-hop) — the browser opens but pages don't load; `pip`/`npm` in a guest wouldn't reach the internet yet. Snapshot/desktop UI unaffected.
- Rebuilding the desktop image in a *live* Lima VM is finicky (boringd holds it open); `setup-local.sh` builds it cleanly on first run.
- **Windows 11 / WSL2** is designed but not implemented/tested (it's the easier path — x86_64, existing images, `/dev/kvm` out of the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local Mac (Apple Silicon) and Windows dev setup for running boring computers
> - Adds [setup-local.sh](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-f265a99307b8f08936eb0503d0d82633a9a790ac9ee3100afecc1addcc965ac2) to provision a Lima VM on Apple Silicon, cross-compile `boringd` for linux/arm64, build rootfs images inside the guest, and expose the service via a forwarded port.
> - Adds [lima-boring.yaml](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-4f530b40e5c1bd526b7760a912ebc5b4369f128723676b5dad9d67510241d659) with an arm64 Ubuntu 24.04 VM config using nested virtualization (`/dev/kvm`) and a host port forward from guest 8080.
> - Makes [bootstrap.sh](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-f5830783f773e3dd02acce5d33a9e8fb4e80f9e4b929283710bfbd179f8c10f7) and [build-rootfs.sh](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-18fc0637724f89ce77adceab0150d640b3add450bc22bbb0e2ebd1c2b847ae8b) arch-aware, selecting the correct Firecracker binaries and Alpine base image for `x86_64` or `aarch64` at runtime.
> - Makes [build-desktop-rootfs.sh](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-b3c3cf9857312401b498ac8bffc4e3a6b89ac8dadbe58f11c4521758aea3afb4) arch-aware: installs the correct Node.js tarball, starts a system dbus, and invokes the Chromium ELF directly to avoid the distro wrapper that fails on arm64.
> - Adds [infra/local/README.md](https://github.com/michaelshimeles/boring-computers/pull/7/files#diff-e7ba7fb3c67e882e531448b5473b373c9062844a882aa714ee27391276c4af1f) with setup steps and caveats for macOS and Windows 11.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a9e970.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/michaelshimeles/boring-computers/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->