### PR TITLE
fix: cache the SDK dist/ output in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"env": ["PUBLIC_BORING_URL"],
-			"outputs": [".svelte-kit/**", "build/**", ".vercel/**"]
+			"outputs": [".svelte-kit/**", "build/**", ".vercel/**", "dist/**"]
 		},
 		"dev": {
 			"cache": false,


### PR DESCRIPTION
Every `npm run build` / `npm run check` currently prints:

```
WARNING  no output files found for task boring-computers-sdk#build. Please check your `outputs` key in turbo.json
```

The SDK compiles into `dist/`, but the shared `build` task's `outputs` only lists `.svelte-kit/**`, `build/**`, and `.vercel/**`, so turbo never captures (or caches) the SDK build.

This adds `dist/**` to the list. Verified locally: the warning is gone, and a repeat `turbo build --filter=boring-computers-sdk` goes from ~16s to a full cache hit (~70ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)