### PR TITLE
fix: read the countdown TTL prop through a getter

### DIFF
--- a/apps/web/src/lib/Computer.svelte
+++ b/apps/web/src/lib/Computer.svelte
@@ -32,7 +32,10 @@
 	let termHandle: TerminalHandle | null = null;
 	let agentWs: WebSocket | null = null;
 
-	const timer = createCountdown(ttl, (r) => (remaining = r));
+	const timer = createCountdown(
+		() => ttl,
+		(r) => (remaining = r)
+	);
 
 	// The component only mounts once the user has asked for a computer, so boot
 	// immediately (bind:this on the parent isn't populated until after mount).

--- a/apps/web/src/lib/Desktop.svelte
+++ b/apps/web/src/lib/Desktop.svelte
@@ -26,7 +26,10 @@
 	let disposed = false;
 
 	const MAX_ATTEMPTS = 10;
-	const timer = createCountdown(ttl, (r) => (remaining = r));
+	const timer = createCountdown(
+		() => ttl,
+		(r) => (remaining = r)
+	);
 
 	onMount(() => {
 		void launch();

--- a/apps/web/src/lib/Workstation.svelte
+++ b/apps/web/src/lib/Workstation.svelte
@@ -211,7 +211,10 @@
 
 	let disposed = false;
 	const MAX_ATTEMPTS = 10;
-	const timer = createCountdown(ttl, (r) => (remaining = r));
+	const timer = createCountdown(
+		() => ttl,
+		(r) => (remaining = r)
+	);
 
 	onMount(() => {
 		void launch();

--- a/apps/web/src/lib/countdown.ts
+++ b/apps/web/src/lib/countdown.ts
@@ -2,7 +2,7 @@ import type { Machine } from '$lib/boring';
 
 /** Manages a self-decrementing countdown from a machine's expiry or a fixed TTL. */
 export function createCountdown(
-	ttl: number,
+	ttl: () => number,
 	onTick: (remaining: number) => void
 ): {
 	start: (machine: Machine | null) => void;
@@ -15,7 +15,7 @@ export function createCountdown(
 		stop();
 		remaining = machine?.expires_at
 			? Math.max(0, Math.round((new Date(machine.expires_at).getTime() - Date.now()) / 1000))
-			: ttl;
+			: ttl();
 		onTick(remaining);
 		interval = setInterval(() => {
 			remaining -= 1;


### PR DESCRIPTION
`npm run check` reports the same warning in three components (`Computer.svelte`, `Desktop.svelte`, `Workstation.svelte`):

```
Warn: This reference only captures the initial value of `ttl`. Did you mean to reference it inside a closure instead? (state_referenced_locally)
```

Each one passes the `ttl` prop to `createCountdown` by value at component init, which freezes it at its initial value. This changes `createCountdown` to take a getter (`ttl: () => number`) and the three call sites to pass `() => ttl`, so the prop is read reactively at the moment the countdown starts.

No behavior change today (`ttl` isn't mutated after mount), but the fallback now stays correct if it ever is — and `svelte-check` goes from 3 warnings to 0. `npm run lint` and `npm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)