### PR TITLE
[stack] feat(web): SvelteKit dashboard + public pages

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,3 +16,23 @@
 # from NEHEMIAH_URL to that host's nehemiahd (localhost:8080), and closes it on exit.
 #   NEHEMIAH_URL=http://localhost:18099
 #   NEHEMIAH_TUNNEL=user@your-box        # or an ~/.ssh/config alias
+
+# --- Managed-cloud dashboard ---
+# Browser-safe Clerk configuration. ClerkJS is loaded from this Frontend API,
+# not from an arbitrary CDN.
+#   PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_replace_me
+#   PUBLIC_CLERK_FRONTEND_API=example.clerk.accounts.dev
+# Server-only control-plane origin used by /dashboard/api. Never prefix PRIVATE_
+# values with PUBLIC_ and never put host or gateway credentials in this app.
+#   PRIVATE_NEHEMIAH_URL=http://127.0.0.1:8081
+
+# --- Public status and support pages ---
+# These origins are read only by the server-rendered /status page. Production
+# requires origin-only HTTPS URLs; local development permits loopback HTTP. The
+# probes call only unauthenticated /healthz and /readyz endpoints and never send
+# tokens, cookies, customer identifiers, or host identifiers.
+#   STATUS_CONTROL_PLANE_URL=https://api.boringcomputers.com
+#   STATUS_GATEWAY_URL=https://gateway.boringcomputers.com
+# Optional public support contacts. Unsafe values are omitted from the page.
+#   PUBLIC_SUPPORT_URL=https://support.boringcomputers.com/help
+#   PUBLIC_SUPPORT_EMAIL=support@boringcomputers.com

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,7 @@
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.3.0",
 		"@types/node": "^24",
-		"@vitest/browser-playwright": "^4.1.8",
+		"@vitest/browser-playwright": "^4.1.10",
 		"eslint": "^10.4.1",
 		"playwright": "^1.60.0",
 		"prettier": "^3.8.3",
@@ -37,13 +37,14 @@
 		"tailwindcss": "^4.3.0",
 		"typescript": "^6.0.3",
 		"vite": "^8.0.16",
-		"vitest": "^4.1.8",
+		"vitest": "^4.1.10",
 		"vitest-browser-svelte": "^2.1.1"
 	},
 	"dependencies": {
 		"@novnc/novnc": "^1.7.0",
 		"@vercel/analytics": "^2.0.1",
 		"@xterm/addon-fit": "^0.10.0",
-		"@xterm/xterm": "^5.5.0"
+		"@xterm/xterm": "^5.5.0",
+		"cookie": "0.7.2"
 	}
 }

--- a/apps/web/src/lib/Agent.svelte
+++ b/apps/web/src/lib/Agent.svelte
@@ -93,27 +93,23 @@
 		agentStarted = true;
 		phase = 'live';
 		caption = 'The AI is looking at the screen…';
-		ws = connectAgent(
-			machine.id,
-			`/v1/machines/${machine.id}/agent?goal=${encodeURIComponent(activeGoal)}`,
-			{
-				onSay: (text) => (caption = text),
-				onDone: (text) => {
+		ws = connectAgent(machine.id, `/v1/machines/${machine.id}/agent`, activeGoal, {
+			onSay: (text) => (caption = text),
+			onDone: (text) => {
+				phase = 'done';
+				caption = text || 'The AI finished the task.';
+			},
+			onError: (text) => {
+				phase = 'error';
+				error = text || 'the agent stopped unexpectedly';
+			},
+			onClose: () => {
+				if (phase === 'live') {
 					phase = 'done';
-					caption = text || 'The AI finished the task.';
-				},
-				onError: (text) => {
-					phase = 'error';
-					error = text || 'the agent stopped unexpectedly';
-				},
-				onClose: () => {
-					if (phase === 'live') {
-						phase = 'done';
-						caption = 'The AI finished.';
-					}
+					caption = 'The AI finished.';
 				}
 			}
-		);
+		});
 	}
 
 	export function close() {

--- a/apps/web/src/lib/Computer.svelte
+++ b/apps/web/src/lib/Computer.svelte
@@ -84,23 +84,19 @@
 		if (!goal || agentRunning || !machine) return;
 		agentRunning = true;
 		agentLine = 'thinking…';
-		agentWs = connectAgent(
-			machine.id,
-			`/v1/machines/${machine.id}/shell-agent?goal=${encodeURIComponent(goal)}`,
-			{
-				onDone: (text) => {
-					agentLine = text || 'done ✓';
-					agentRunning = false;
-				},
-				onError: (text) => {
-					agentLine = '⚠ ' + text;
-					agentRunning = false;
-				},
-				onSay: (text) => (agentLine = text),
-				onAction: (text) => (agentLine = text),
-				onClose: () => (agentRunning = false)
-			}
-		);
+		agentWs = connectAgent(machine.id, `/v1/machines/${machine.id}/shell-agent`, goal, {
+			onDone: (text) => {
+				agentLine = text || 'done ✓';
+				agentRunning = false;
+			},
+			onError: (text) => {
+				agentLine = '⚠ ' + text;
+				agentRunning = false;
+			},
+			onSay: (text) => (agentLine = text),
+			onAction: (text) => (agentLine = text),
+			onClose: () => (agentRunning = false)
+		});
 	}
 
 	function aiKey(e: KeyboardEvent) {
@@ -193,6 +189,7 @@
 					<span class="font-mono text-[11px] font-semibold text-accent">AI</span>
 					<input
 						bind:value={agentGoal}
+						maxlength="4096"
 						onkeydown={aiKey}
 						disabled={agentRunning}
 						placeholder="tell the computer what to do — e.g. “build a snake game in python and run it”"

--- a/apps/web/src/lib/Workstation.svelte
+++ b/apps/web/src/lib/Workstation.svelte
@@ -311,13 +311,13 @@
 			if (vncHandle?.rfb) vncHandle.rfb.viewOnly = true;
 		}
 		const path = build
-			? `/v1/machines/${machine.id}/shell-agent?goal=${encodeURIComponent(g)}`
-			: `/v1/machines/${machine.id}/agent?goal=${encodeURIComponent(g)}`;
+			? `/v1/machines/${machine.id}/shell-agent`
+			: `/v1/machines/${machine.id}/agent`;
 		const finish = () => {
 			agentRunning = false;
 			if (!build && vncHandle?.rfb) vncHandle.rfb.viewOnly = false;
 		};
-		agentWs = connectAgent(machine.id, path, {
+		agentWs = connectAgent(machine.id, path, g, {
 			onPreview: (text) => {
 				const port = parseInt(text, 10);
 				if (machine && Number.isInteger(port)) previewLink = previewUrl(machine.id, port);
@@ -560,6 +560,7 @@
 			</span>
 			<input
 				bind:value={goal}
+				maxlength="4096"
 				onkeydown={promptKey}
 				disabled={agentRunning || phase !== 'live'}
 				placeholder={agentMode === 'build'

--- a/apps/web/src/lib/agent-ws.ts
+++ b/apps/web/src/lib/agent-ws.ts
@@ -21,9 +21,26 @@ export interface AgentCallbacks {
 export function connectAgent(
 	machineId: string,
 	path: string,
+	goal: string,
 	callbacks: AgentCallbacks
 ): WebSocket {
 	const ws = new WebSocket(wsUrl(path));
+	const normalizedGoal = goal.trim();
+	const goalBytes = new TextEncoder().encode(normalizedGoal).byteLength;
+	const startFrame = JSON.stringify({ type: 'start', version: 1, goal: normalizedGoal });
+
+	ws.onopen = () => {
+		if (
+			goalBytes < 1 ||
+			goalBytes > 4096 ||
+			new TextEncoder().encode(startFrame).byteLength > 64 * 1024
+		) {
+			callbacks.onError?.('the agent goal must be between 1 and 4096 UTF-8 bytes');
+			ws.close(1008, 'invalid_start_frame');
+			return;
+		}
+		ws.send(startFrame);
+	};
 
 	ws.onmessage = (e) => {
 		let m: AgentMessage;

--- a/apps/web/src/lib/clerk.ts
+++ b/apps/web/src/lib/clerk.ts
@@ -1,0 +1,62 @@
+import { env } from '$env/dynamic/public';
+
+export interface ClerkSession {
+	getToken(options?: { template?: string }): Promise<string | null>;
+}
+
+export interface ClerkLike {
+	readonly user: { readonly id: string; readonly fullName?: string | null } | null;
+	readonly session: ClerkSession | null;
+	load(): Promise<void>;
+	openSignIn(): void;
+	signOut(): Promise<void>;
+	addListener(listener: () => void): () => void;
+}
+
+declare global {
+	interface Window {
+		Clerk?: ClerkLike;
+	}
+}
+
+let loading: Promise<ClerkLike> | undefined;
+
+/** Load ClerkJS from the instance's own Frontend API, as recommended for vanilla JS apps. */
+export const loadClerk = (): Promise<ClerkLike> => {
+	if (loading) return loading;
+	loading = new Promise((resolve, reject) => {
+		const publishableKey = env.PUBLIC_CLERK_PUBLISHABLE_KEY;
+		const frontendApi = env.PUBLIC_CLERK_FRONTEND_API;
+		if (!publishableKey || !frontendApi || !/^[a-zA-Z0-9.-]+$/.test(frontendApi)) {
+			reject(new Error('Clerk dashboard authentication is not configured'));
+			return;
+		}
+		const finish = async () => {
+			if (!window.Clerk) throw new Error('ClerkJS did not initialize');
+			await window.Clerk.load();
+			resolve(window.Clerk);
+		};
+		if (window.Clerk) {
+			void finish().catch(reject);
+			return;
+		}
+		const script = document.createElement('script');
+		script.async = true;
+		script.crossOrigin = 'anonymous';
+		script.dataset.clerkPublishableKey = publishableKey;
+		script.src = `https://${frontendApi}/npm/@clerk/clerk-js@6/dist/clerk.browser.js`;
+		script.addEventListener('load', () => void finish().catch(reject), { once: true });
+		script.addEventListener('error', () => reject(new Error('Could not load ClerkJS')), {
+			once: true
+		});
+		document.head.append(script);
+	});
+	return loading;
+};
+
+export const clerkToken = async (): Promise<string> => {
+	const clerk = await loadClerk();
+	const token = await clerk.session?.getToken();
+	if (!token) throw new Error('Sign in to continue');
+	return token;
+};

--- a/apps/web/src/lib/countdown.ts
+++ b/apps/web/src/lib/countdown.ts
@@ -2,7 +2,7 @@ import type { Machine } from '$lib/boring';
 
 /** Manages a self-decrementing countdown from a machine's expiry or a fixed TTL. */
 export function createCountdown(
-	ttl: () => number,
+	ttl: number | (() => number),
 	onTick: (remaining: number) => void
 ): {
 	start: (machine: Machine | null) => void;
@@ -15,7 +15,9 @@ export function createCountdown(
 		stop();
 		remaining = machine?.expires_at
 			? Math.max(0, Math.round((new Date(machine.expires_at).getTime() - Date.now()) / 1000))
-			: ttl();
+			: typeof ttl === 'function'
+				? ttl()
+				: ttl;
 		onTick(remaining);
 		interval = setInterval(() => {
 			remaining -= 1;

--- a/apps/web/src/lib/durable-operation.test.ts
+++ b/apps/web/src/lib/durable-operation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { durableOperation, type StorageLike } from './durable-operation';
+
+class MemoryStorage implements StorageLike {
+	value: string | null = null;
+	getItem(): string | null {
+		return this.value;
+	}
+	setItem(_key: string, value: string): void {
+		this.value = value;
+	}
+}
+
+describe('durableOperation', () => {
+	it('reuses one key for the same canonical operation until completion', () => {
+		const storage = new MemoryStorage();
+		const keys = vi.fn(() => 'stable-operation-key');
+		const first = durableOperation(
+			storage,
+			'machine:create:project',
+			{ ttl: 60, size: 1 },
+			keys,
+			1
+		);
+		const retry = durableOperation(
+			storage,
+			'machine:create:project',
+			{ size: 1, ttl: 60 },
+			keys,
+			2
+		);
+		expect(retry.idempotencyKey).toBe(first.idempotencyKey);
+		expect(keys).toHaveBeenCalledTimes(1);
+
+		first.complete();
+		keys.mockReturnValue('next-operation-key');
+		expect(
+			durableOperation(storage, 'machine:create:project', { ttl: 60, size: 1 }, keys, 3)
+				.idempotencyKey
+		).toBe('next-operation-key');
+	});
+
+	it('does not overwrite an ambiguous operation when the payload changes', () => {
+		const storage = new MemoryStorage();
+		const keys = vi.fn().mockReturnValueOnce('first-key').mockReturnValueOnce('second-key');
+		expect(durableOperation(storage, 'fork:m1', { count: 1 }, keys, 1).idempotencyKey).toBe(
+			'first-key'
+		);
+		expect(durableOperation(storage, 'fork:m1', { count: 2 }, keys, 2).idempotencyKey).toBe(
+			'second-key'
+		);
+		expect(durableOperation(storage, 'fork:m1', { count: 1 }, keys, 3).idempotencyKey).toBe(
+			'first-key'
+		);
+	});
+
+	it('rejects poisoned persisted keys instead of putting them in a header', () => {
+		const storage = new MemoryStorage();
+		storage.value = JSON.stringify([
+			{ scope: 'create', payload: '{}', idempotencyKey: 'bad\r\nheader', createdAt: 1 }
+		]);
+		expect(durableOperation(storage, 'create', {}, () => 'safe-key', 2).idempotencyKey).toBe(
+			'safe-key'
+		);
+	});
+
+	it('fails before a request when a new recovery key cannot be persisted', () => {
+		const storage: StorageLike = {
+			getItem: () => null,
+			setItem: () => {
+				throw new Error('storage disabled');
+			}
+		};
+		expect(() => durableOperation(storage, 'create', {}, () => 'safe-key', 2)).toThrow(
+			'request was not sent'
+		);
+	});
+});

--- a/apps/web/src/lib/durable-operation.ts
+++ b/apps/web/src/lib/durable-operation.ts
@@ -1,0 +1,94 @@
+const storageKey = 'nehemiah.pending-idempotency.v1';
+const maximumRecords = 128;
+const maximumAgeMs = 7 * 24 * 60 * 60 * 1_000;
+const validKey = /^[A-Za-z0-9._:-]{1,200}$/;
+
+interface StoredOperation {
+	readonly scope: string;
+	readonly payload: string;
+	readonly idempotencyKey: string;
+	readonly createdAt: number;
+}
+
+export interface StorageLike {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+}
+
+const canonical = (value: unknown): string => {
+	if (value === null || typeof value !== 'object') return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+	return `{${Object.entries(value as Record<string, unknown>)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`)
+		.join(',')}}`;
+};
+
+const read = (storage: StorageLike, now: number): StoredOperation[] => {
+	try {
+		const decoded = JSON.parse(storage.getItem(storageKey) ?? '[]') as unknown;
+		if (!Array.isArray(decoded)) return [];
+		return decoded
+			.filter(
+				(value): value is StoredOperation =>
+					typeof value === 'object' &&
+					value !== null &&
+					typeof (value as StoredOperation).scope === 'string' &&
+					typeof (value as StoredOperation).payload === 'string' &&
+					validKey.test((value as StoredOperation).idempotencyKey) &&
+					Number.isSafeInteger((value as StoredOperation).createdAt) &&
+					(value as StoredOperation).createdAt <= now &&
+					now - (value as StoredOperation).createdAt <= maximumAgeMs
+			)
+			.slice(-maximumRecords);
+	} catch {
+		return [];
+	}
+};
+
+const write = (storage: StorageLike, records: ReadonlyArray<StoredOperation>): boolean => {
+	try {
+		storage.setItem(storageKey, JSON.stringify(records.slice(-maximumRecords)));
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const durableOperation = (
+	storage: StorageLike,
+	scope: string,
+	payload: unknown,
+	keyFactory: () => string = () => crypto.randomUUID(),
+	now = Date.now()
+): { readonly idempotencyKey: string; readonly complete: () => void } => {
+	if (!scope || scope.length > 512) throw new Error('operation scope is invalid');
+	const encodedPayload = canonical(payload);
+	if (encodedPayload.length > 16_384) throw new Error('operation payload is too large');
+	const records = read(storage, now);
+	let record = records.find(
+		(candidate) => candidate.scope === scope && candidate.payload === encodedPayload
+	);
+	if (!record) {
+		const idempotencyKey = keyFactory();
+		if (!validKey.test(idempotencyKey)) throw new Error('generated idempotency key is invalid');
+		record = { scope, payload: encodedPayload, idempotencyKey, createdAt: now };
+		records.push(record);
+		if (!write(storage, records)) {
+			throw new Error('Durable operation storage is unavailable; the request was not sent.');
+		}
+	}
+	return {
+		idempotencyKey: record.idempotencyKey,
+		complete: () =>
+			write(
+				storage,
+				read(storage, Date.now()).filter(
+					(candidate) =>
+						candidate.scope !== scope ||
+						candidate.payload !== encodedPayload ||
+						candidate.idempotencyKey !== record.idempotencyKey
+				)
+			)
+	};
+};

--- a/apps/web/src/lib/nehemiah-client.test.ts
+++ b/apps/web/src/lib/nehemiah-client.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DashboardApiError,
+	machinePreviewUrl,
+	machineWebSocketSession,
+	organizationForDashboard,
+	type DashboardMachineSession
+} from './nehemiah-client';
+
+describe('dashboard client errors', () => {
+	it('prefers RFC 9457 detail text', () => {
+		const error = new DashboardApiError(403, {
+			title: 'insufficient_scope',
+			detail: 'machines:write is required.'
+		});
+		expect(error.message).toBe('machines:write is required.');
+		expect(error.status).toBe(403);
+	});
+});
+
+describe('dashboard organization selection', () => {
+	const organizations = [{ id: 'org-a' }, { id: 'org-b' }];
+
+	it('keeps a previous selection that the user can still access', () => {
+		expect(organizationForDashboard(organizations, 'org-b')).toBe('org-b');
+	});
+
+	it('falls back to the first organization when a stored selection is stale', () => {
+		expect(organizationForDashboard(organizations, 'org-removed')).toBe('org-a');
+	});
+
+	it('returns undefined when the user has no organizations', () => {
+		expect(organizationForDashboard([], 'org-a')).toBeUndefined();
+	});
+});
+
+describe('machine session links', () => {
+	const session: DashboardMachineSession = {
+		token: 'short-lived-capability',
+		expires_in: 300,
+		gateway_url: 'https://gateway.example/base?ignored=yes'
+	};
+
+	it('keeps credentials out of the WebSocket URL and uses a scoped subprotocol', () => {
+		expect(machineWebSocketSession(session, 'm_123', 'tty')).toEqual({
+			url: 'wss://gateway.example/v1/machines/m_123/tty',
+			protocols: ['nehemiah.capability.short-lived-capability']
+		});
+	});
+
+	it('accepts a wildcard preview origin with fragment-based authentication', () => {
+		expect(
+			machinePreviewUrl(
+				{
+					...session,
+					preview_url:
+						'https://lease--3000.preview.example/preview/m_123/3000/#token=short-lived-bootstrap'
+				},
+				'm_123',
+				3000
+			)
+		).toBe('https://lease--3000.preview.example/preview/m_123/3000/#token=short-lived-bootstrap');
+	});
+
+	it('rejects query-string preview authentication', () => {
+		expect(() =>
+			machinePreviewUrl(
+				{
+					...session,
+					preview_url:
+						'https://lease--3000.preview.example/preview/m_123/3000/?token=leaked#token=bootstrap'
+				},
+				'm_123',
+				3000
+			)
+		).toThrow('preview URL is invalid');
+	});
+
+	it('rejects a preview URL for a different machine or port', () => {
+		expect(() =>
+			machinePreviewUrl(
+				{
+					...session,
+					preview_url: 'https://lease--3001.preview.example/preview/m_other/3001/#token=bootstrap'
+				},
+				'm_123',
+				3000
+			)
+		).toThrow('preview URL is invalid');
+	});
+
+	it('rejects preview credentials embedded in the URL authority', () => {
+		expect(() =>
+			machinePreviewUrl(
+				{
+					...session,
+					preview_url:
+						'https://user:secret@lease--3000.preview.example/preview/m_123/3000/#token=bootstrap'
+				},
+				'm_123',
+				3000
+			)
+		).toThrow('preview URL is invalid');
+	});
+});

--- a/apps/web/src/lib/nehemiah-client.ts
+++ b/apps/web/src/lib/nehemiah-client.ts
@@ -1,0 +1,126 @@
+import { clerkToken } from './clerk';
+
+export interface DashboardProblem {
+	readonly title?: string;
+	readonly detail?: string;
+	readonly status?: number;
+}
+
+export class DashboardApiError extends Error {
+	constructor(
+		readonly status: number,
+		readonly problem: DashboardProblem
+	) {
+		super(problem.detail ?? problem.title ?? `Request failed (${status})`);
+	}
+}
+
+export interface OrganizationOption {
+	readonly id: string;
+}
+
+export interface DashboardMachineSession {
+	readonly token: string;
+	readonly expires_in: number;
+	readonly gateway_url: string;
+	readonly preview_url?: string;
+}
+
+/** Keep a valid prior choice, otherwise make a deterministic first selection. */
+export const organizationForDashboard = (
+	organizations: ReadonlyArray<OrganizationOption>,
+	previous?: string
+): string | undefined =>
+	previous && organizations.some((organization) => organization.id === previous)
+		? previous
+		: organizations[0]?.id;
+
+const gatewayUrl = (value: string): URL => {
+	const url = new URL(value);
+	if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+		throw new Error('The session gateway URL is invalid');
+	}
+	url.username = '';
+	url.password = '';
+	url.search = '';
+	url.hash = '';
+	return url;
+};
+
+export interface DashboardWebSocketSession {
+	readonly url: string;
+	readonly protocols: readonly [string];
+}
+
+export const machineWebSocketSession = (
+	session: DashboardMachineSession,
+	machineId: string,
+	capability: 'tty' | 'vnc'
+): DashboardWebSocketSession => {
+	const url = gatewayUrl(session.gateway_url);
+	url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+	url.pathname = `/v1/machines/${encodeURIComponent(machineId)}/${capability}`;
+	return {
+		url: url.toString(),
+		protocols: [`nehemiah.capability.${session.token}`]
+	};
+};
+
+export const machinePreviewUrl = (
+	session: DashboardMachineSession,
+	machineId: string,
+	port: number
+): string => {
+	gatewayUrl(session.gateway_url);
+	if (!session.preview_url) throw new Error('The preview session did not include a URL');
+	const supplied = new URL(session.preview_url);
+	const fragment = new URLSearchParams(supplied.hash.slice(1));
+	const fragmentTokens = fragment.getAll('token');
+	if (
+		(supplied.protocol !== 'https:' && supplied.protocol !== 'http:') ||
+		supplied.username !== '' ||
+		supplied.password !== '' ||
+		supplied.pathname !== `/preview/${encodeURIComponent(machineId)}/${port}/` ||
+		supplied.search !== '' ||
+		fragmentTokens.length !== 1 ||
+		fragmentTokens[0] === '' ||
+		[...fragment.keys()].some((key) => key !== 'token')
+	) {
+		throw new Error('The preview URL is invalid');
+	}
+	// Production previews may use a per-lease wildcard origin. The control plane
+	// and gateway bind that host cryptographically; dashboard code keeps the
+	// fragment-based bootstrap opaque and never turns it into query auth.
+	return supplied.toString();
+};
+
+export const selectedOrganization = (): string | undefined =>
+	typeof localStorage === 'undefined'
+		? undefined
+		: (localStorage.getItem('nehemiah.organization') ?? undefined);
+
+export const selectOrganization = (id: string): void => {
+	if (typeof localStorage !== 'undefined') localStorage.setItem('nehemiah.organization', id);
+};
+
+export const dashboardApi = async <T>(
+	path: string,
+	init: RequestInit = {},
+	organizationId = selectedOrganization()
+): Promise<T> => {
+	const token = await clerkToken();
+	const response = await fetch(`/dashboard/api${path.startsWith('/') ? path : `/${path}`}`, {
+		...init,
+		headers: {
+			authorization: `Bearer ${token}`,
+			...(organizationId ? { 'x-nehemiah-organization-id': organizationId } : {}),
+			...(init.body ? { 'content-type': 'application/json' } : {}),
+			...init.headers
+		}
+	});
+	if (!response.ok) {
+		const problem = (await response.json().catch(() => ({}))) as DashboardProblem;
+		throw new DashboardApiError(response.status, problem);
+	}
+	return response.status === 204 ? (undefined as T) : ((await response.json()) as T);
+};

--- a/apps/web/src/lib/public-support.test.ts
+++ b/apps/web/src/lib/public-support.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { publicSupportConfig } from './public-support';
+
+describe('public support configuration', () => {
+	it('returns only bounded public HTTPS contact values', () => {
+		expect(
+			publicSupportConfig(
+				{
+					url: 'https://support.example.com/help',
+					email: 'help+cloud@Example.com'
+				},
+				true
+			)
+		).toEqual({
+			url: 'https://support.example.com/help',
+			email: 'help+cloud@example.com'
+		});
+	});
+
+	it('omits unsafe URL credentials, CRLF, query data, and malformed mail addresses', () => {
+		for (const input of [
+			{ url: 'https://user:secret@support.example.com/help' },
+			{ url: 'https://support.example.com/help?token=secret' },
+			{ url: 'https://support.example.com/help%0d%0aheader' },
+			{ url: 'http://support.example.com/help' },
+			{ url: 'https://localhost/help' },
+			{ email: 'support@example.com\r\nBcc:attacker@example.com' },
+			{ email: 'Support Team <support@example.com>' },
+			{ email: `${'a'.repeat(255)}@example.com` }
+		]) {
+			expect(publicSupportConfig(input, true)).toEqual({});
+		}
+	});
+
+	it('allows HTTP only for a loopback development support portal', () => {
+		expect(
+			publicSupportConfig(
+				{ url: 'http://127.0.0.1:5173/support', email: 'support@localhost' },
+				false
+			)
+		).toEqual({
+			url: 'http://127.0.0.1:5173/support',
+			email: 'support@localhost'
+		});
+	});
+});

--- a/apps/web/src/lib/public-support.ts
+++ b/apps/web/src/lib/public-support.ts
@@ -1,0 +1,103 @@
+export interface PublicSupportConfig {
+	readonly url?: string;
+	readonly email?: string;
+}
+
+const hasControlCharacter = (value: string): boolean =>
+	[...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code <= 31 || code === 127;
+	});
+
+const hasNonEmailCharacter = (value: string): boolean =>
+	[...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code <= 32 || code >= 127;
+	});
+
+const loopbackHostname = (hostname: string): boolean => {
+	if (hostname === 'localhost' || hostname === '[::1]') return true;
+	const octets = hostname.split('.');
+	return (
+		octets.length === 4 &&
+		octets[0] === '127' &&
+		octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
+	);
+};
+
+const safeSupportUrl = (value: string | undefined, production: boolean): string | undefined => {
+	if (
+		!value ||
+		value.length > 2_048 ||
+		value.trim() !== value ||
+		hasControlCharacter(value) ||
+		/%(?:0a|0d)/i.test(value)
+	) {
+		return undefined;
+	}
+	try {
+		const url = new URL(value);
+		const loopback = loopbackHostname(url.hostname);
+		if (
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash ||
+			url.hostname.endsWith('.') ||
+			(production && (url.protocol !== 'https:' || loopback)) ||
+			(!production && url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback))
+		) {
+			return undefined;
+		}
+		return url.toString();
+	} catch {
+		return undefined;
+	}
+};
+
+const safeSupportEmail = (value: string | undefined, production: boolean): string | undefined => {
+	if (!value || value.length > 254 || value.trim() !== value || hasNonEmailCharacter(value)) {
+		return undefined;
+	}
+	const parts = value.split('@');
+	if (parts.length !== 2) return undefined;
+	const [local, rawDomain] = parts;
+	if (
+		!local ||
+		!rawDomain ||
+		local.length > 64 ||
+		local.startsWith('.') ||
+		local.endsWith('.') ||
+		local.includes('..') ||
+		!/^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+$/.test(local)
+	) {
+		return undefined;
+	}
+	const domain = rawDomain.toLowerCase();
+	if (production && !domain.includes('.')) return undefined;
+	if (
+		domain.length > 253 ||
+		domain.includes('..') ||
+		domain
+			.split('.')
+			.some(
+				(label) =>
+					label.length === 0 ||
+					label.length > 63 ||
+					!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+			)
+	) {
+		return undefined;
+	}
+	return `${local}@${domain}`;
+};
+
+/** Unsafe deployment values are omitted rather than reflected into public HTML. */
+export const publicSupportConfig = (
+	input: PublicSupportConfig,
+	production: boolean
+): PublicSupportConfig => {
+	const url = safeSupportUrl(input.url, production);
+	const email = safeSupportEmail(input.email, production);
+	return { ...(url ? { url } : {}), ...(email ? { email } : {}) };
+};

--- a/apps/web/src/lib/server/control-plane-origin.test.ts
+++ b/apps/web/src/lib/server/control-plane-origin.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { controlPlaneOrigin } from './control-plane-origin';
+
+describe('controlPlaneOrigin', () => {
+	it('accepts only a bare HTTPS production origin', () => {
+		expect(controlPlaneOrigin('https://api.example.test/', false)).toBe('https://api.example.test');
+		for (const value of [
+			'http://api.example.test',
+			'https://user:pass@api.example.test',
+			'https://api.example.test/v1',
+			'https://api.example.test?x=1',
+			'https://api.example.test/#x',
+			'not-a-url'
+		]) {
+			expect(controlPlaneOrigin(value, false)).toBeUndefined();
+		}
+	});
+
+	it('allows HTTP only on exact loopback hosts in development', () => {
+		for (const value of ['http://localhost:8081', 'http://127.0.0.1:8081', 'http://[::1]:8081']) {
+			expect(controlPlaneOrigin(value, true)).toBe(value);
+		}
+		expect(controlPlaneOrigin('http://localhost.example:8081', true)).toBeUndefined();
+		expect(controlPlaneOrigin('http://192.0.2.1:8081', true)).toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/server/control-plane-origin.ts
+++ b/apps/web/src/lib/server/control-plane-origin.ts
@@ -1,0 +1,27 @@
+const loopbackHostname = (hostname: string): boolean =>
+	hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+
+export const controlPlaneOrigin = (
+	value: string | undefined,
+	development: boolean
+): string | undefined => {
+	if (!value) return undefined;
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return undefined;
+	}
+	if (
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		(url.pathname !== '' && url.pathname !== '/')
+	) {
+		return undefined;
+	}
+	if (url.protocol === 'https:') return url.origin;
+	if (development && url.protocol === 'http:' && loopbackHostname(url.hostname)) return url.origin;
+	return undefined;
+};

--- a/apps/web/src/lib/server/public-status.test.ts
+++ b/apps/web/src/lib/server/public-status.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	collectPublicStatus,
+	PUBLIC_STATUS_CACHE_CONTROL,
+	safeProbeOrigin,
+	STATUS_PROBE_TIMEOUT_MS,
+	STATUS_RESPONSE_LIMIT_BYTES
+} from './public-status';
+
+const response = (status: number, body = '{}'): Response =>
+	new Response(body, { status, headers: { 'content-type': 'application/json' } });
+
+describe('public status probes', () => {
+	it('uses a short public cache window with stale-while-revalidate', () => {
+		expect(PUBLIC_STATUS_CACHE_CONTROL).toContain('max-age=15');
+		expect(PUBLIC_STATUS_CACHE_CONTROL).toContain('s-maxage=15');
+		expect(PUBLIC_STATUS_CACHE_CONTROL).toContain('stale-while-revalidate=30');
+		expect(PUBLIC_STATUS_CACHE_CONTROL).not.toMatch(/max-age=(?:3[1-9]|[4-9]\d|\d{3,})/);
+	});
+
+	it('rejects unsafe or non-origin probe URLs without making a request', async () => {
+		for (const value of [
+			'http://api.example.com',
+			'https://user:secret@api.example.com',
+			'https://api.example.com/private',
+			'https://api.example.com/?token=secret',
+			'https://api.example.com/#internal',
+			'https://localhost:8081'
+		]) {
+			expect(safeProbeOrigin(value, true)).toBeUndefined();
+		}
+		expect(safeProbeOrigin('http://api.example.com', false)).toBeUndefined();
+		expect(safeProbeOrigin('http://127.0.0.1:8081', false)).toBe('http://127.0.0.1:8081');
+
+		const fetch = vi.fn<typeof globalThis.fetch>();
+		const result = await collectPublicStatus(
+			{
+				controlPlaneUrl: 'https://api.example.com/private',
+				gatewayUrl: 'file:///tmp/gateway',
+				production: true
+			},
+			{ fetch, now: () => new Date('2026-08-09T12:00:00.000Z') }
+		);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			status: 'unknown',
+			components: { control_plane: 'unknown', gateway: 'unknown' },
+			checked_at: '2026-08-09T12:00:00.000Z'
+		});
+	});
+
+	it('runs the three credential-free probes and reduces mixed health to coarse statuses', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+			const url = new URL(input instanceof Request ? input.url : String(input));
+			if (url.hostname === 'control.example.com' && url.pathname === '/healthz') {
+				return response(200);
+			}
+			if (url.hostname === 'control.example.com' && url.pathname === '/readyz') {
+				return response(503);
+			}
+			if (url.hostname === 'gateway.example.com' && url.pathname === '/healthz') {
+				return response(200);
+			}
+			throw new Error('unexpected probe target');
+		});
+
+		const result = await collectPublicStatus(
+			{
+				controlPlaneUrl: 'https://control.example.com',
+				gatewayUrl: 'https://gateway.example.com',
+				production: true
+			},
+			{ fetch, now: () => new Date('2026-08-09T12:00:00.000Z') }
+		);
+
+		expect(fetch).toHaveBeenCalledTimes(3);
+		for (const [input, init] of fetch.mock.calls) {
+			const url = new URL(input instanceof Request ? input.url : String(input));
+			expect(url.search).toBe('');
+			expect(init).toMatchObject({
+				method: 'GET',
+				redirect: 'error',
+				credentials: 'omit',
+				cache: 'no-store',
+				referrerPolicy: 'no-referrer'
+			});
+			const headers = new Headers(init?.headers);
+			expect(headers.get('authorization')).toBeNull();
+			expect(headers.get('cookie')).toBeNull();
+		}
+		expect(result).toEqual({
+			status: 'degraded',
+			components: { control_plane: 'degraded', gateway: 'operational' },
+			checked_at: '2026-08-09T12:00:00.000Z'
+		});
+	});
+
+	it('aborts a hung request at the bounded timeout', async () => {
+		expect(STATUS_PROBE_TIMEOUT_MS).toBe(2_000);
+		const signals: AbortSignal[] = [];
+		const fetch = vi.fn<typeof globalThis.fetch>(
+			(_input, init) =>
+				new Promise<Response>((_resolve, reject) => {
+					const signal = init?.signal;
+					if (!signal) return reject(new Error('missing signal'));
+					signals.push(signal);
+					signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+				})
+		);
+		const result = await collectPublicStatus(
+			{ gatewayUrl: 'https://gateway.example.com', production: true },
+			{ fetch, timeoutMs: 5, now: () => new Date('2026-08-09T12:00:00.000Z') }
+		);
+		expect(fetch).toHaveBeenCalledOnce();
+		expect(signals).toHaveLength(1);
+		expect(signals[0]?.aborted).toBe(true);
+		expect(result.status).toBe('unknown');
+	});
+
+	it('cancels and discards a streamed body as soon as it exceeds 16 KiB', async () => {
+		expect(STATUS_RESPONSE_LIMIT_BYTES).toBe(16_384);
+		let cancelled = false;
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array(8_192));
+				controller.enqueue(new Uint8Array(8_193));
+			},
+			cancel() {
+				cancelled = true;
+			}
+		});
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(body));
+		const result = await collectPublicStatus(
+			{ gatewayUrl: 'https://gateway.example.com', production: true },
+			{ fetch }
+		);
+		expect(cancelled).toBe(true);
+		expect(result.components.gateway).toBe('unknown');
+	});
+
+	it('refuses redirects instead of following a server-provided location', async () => {
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValue(
+				new Response(null, { status: 302, headers: { location: 'https://attacker.invalid/' } })
+			);
+		const result = await collectPublicStatus(
+			{ gatewayUrl: 'https://gateway.example.com', production: true },
+			{ fetch }
+		);
+		expect(fetch.mock.calls[0]?.[1]?.redirect).toBe('error');
+		expect(result.components.gateway).toBe('unknown');
+	});
+
+	it('never reflects upstream bodies, errors, URLs, credentials, or private identifiers', async () => {
+		const upstream = {
+			detail: 'database at db.private.internal failed',
+			api_key: 'bc_live_do-not-leak',
+			host_id: 'host-private-123',
+			customer_id: 'customer-private-456'
+		};
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValue(response(500, JSON.stringify(upstream)));
+		const result = await collectPublicStatus(
+			{ gatewayUrl: 'https://gateway.example.com', production: true },
+			{ fetch, now: () => new Date('2026-08-09T12:00:00.000Z') }
+		);
+		const serialized = JSON.stringify(result);
+		for (const forbidden of Object.values(upstream)) expect(serialized).not.toContain(forbidden);
+		expect(serialized).not.toContain('gateway.example.com');
+		expect(result).toEqual({
+			status: 'outage',
+			components: { control_plane: 'unknown', gateway: 'outage' },
+			checked_at: '2026-08-09T12:00:00.000Z'
+		});
+	});
+});

--- a/apps/web/src/lib/server/public-status.ts
+++ b/apps/web/src/lib/server/public-status.ts
@@ -1,0 +1,203 @@
+import { isIP } from 'node:net';
+
+export const STATUS_PROBE_TIMEOUT_MS = 2_000;
+export const STATUS_RESPONSE_LIMIT_BYTES = 16_384;
+export const PUBLIC_STATUS_CACHE_CONTROL =
+	'public, max-age=15, s-maxage=15, stale-while-revalidate=30';
+
+export type PublicComponentStatus = 'operational' | 'degraded' | 'outage' | 'unknown';
+
+export interface PublicStatusSnapshot {
+	readonly status: PublicComponentStatus;
+	readonly components: {
+		readonly control_plane: PublicComponentStatus;
+		readonly gateway: PublicComponentStatus;
+	};
+	readonly checked_at: string;
+}
+
+export interface PublicStatusInput {
+	readonly controlPlaneUrl?: string;
+	readonly gatewayUrl?: string;
+	readonly production: boolean;
+}
+
+export interface PublicStatusDependencies {
+	readonly fetch?: typeof globalThis.fetch;
+	readonly now?: () => Date;
+	/** Test-only clock compression; production callers use the fixed 2 second default. */
+	readonly timeoutMs?: number;
+}
+
+type ProbeResult = 'healthy' | 'unhealthy' | 'unknown';
+
+const hasControlCharacter = (value: string): boolean =>
+	[...value].some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code <= 31 || code === 127;
+	});
+
+const isLoopback = (hostname: string): boolean => {
+	const unwrapped =
+		hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+	if (unwrapped === 'localhost' || unwrapped === '::1') return true;
+	return isIP(unwrapped) === 4 && unwrapped.startsWith('127.');
+};
+
+/** Accept only an origin. HTTP and loopback are limited to local development. */
+export const safeProbeOrigin = (
+	value: string | undefined,
+	production: boolean
+): string | undefined => {
+	if (!value || value.length > 2_048 || value.trim() !== value || hasControlCharacter(value)) {
+		return undefined;
+	}
+	try {
+		const url = new URL(value);
+		const loopback = isLoopback(url.hostname);
+		if (
+			url.username ||
+			url.password ||
+			url.pathname !== '/' ||
+			url.search ||
+			url.hash ||
+			url.hostname.endsWith('.') ||
+			(production && (url.protocol !== 'https:' || loopback)) ||
+			(!production && url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback))
+		) {
+			return undefined;
+		}
+		return url.origin;
+	} catch {
+		return undefined;
+	}
+};
+
+const consumeBounded = async (response: Response, signal: AbortSignal): Promise<boolean> => {
+	const length = response.headers.get('content-length');
+	if (length && /^\d+$/.test(length) && Number(length) > STATUS_RESPONSE_LIMIT_BYTES) {
+		await response.body?.cancel().catch(() => undefined);
+		return false;
+	}
+	if (!response.body) return true;
+
+	const reader = response.body.getReader();
+	const cancel = (): void => void reader.cancel().catch(() => undefined);
+	if (signal.aborted) cancel();
+	else signal.addEventListener('abort', cancel, { once: true });
+	let bytes = 0;
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) return true;
+			bytes += value.byteLength;
+			if (bytes > STATUS_RESPONSE_LIMIT_BYTES) {
+				await reader.cancel().catch(() => undefined);
+				return false;
+			}
+		}
+	} catch {
+		return false;
+	} finally {
+		signal.removeEventListener('abort', cancel);
+	}
+};
+
+const probe = async (
+	origin: string,
+	path: '/healthz' | '/readyz',
+	fetchImplementation: typeof globalThis.fetch,
+	timeoutMs: number
+): Promise<ProbeResult> => {
+	const controller = new AbortController();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<ProbeResult>((resolve) => {
+		timer = setTimeout(() => {
+			controller.abort();
+			resolve('unknown');
+		}, timeoutMs);
+	});
+	const operation = (async (): Promise<ProbeResult> => {
+		try {
+			const response = await fetchImplementation(new URL(path, origin), {
+				method: 'GET',
+				redirect: 'error',
+				credentials: 'omit',
+				cache: 'no-store',
+				referrerPolicy: 'no-referrer',
+				signal: controller.signal,
+				headers: { accept: 'application/json' }
+			});
+			if (response.redirected || (response.status >= 300 && response.status < 400)) {
+				await response.body?.cancel().catch(() => undefined);
+				return 'unknown';
+			}
+			if (!(await consumeBounded(response, controller.signal))) return 'unknown';
+			if (response.ok) return 'healthy';
+			return response.status >= 500 ? 'unhealthy' : 'unknown';
+		} catch {
+			return 'unknown';
+		}
+	})();
+
+	try {
+		return await Promise.race([operation, timeout]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+};
+
+const controlPlaneStatus = (
+	liveness: ProbeResult,
+	readiness: ProbeResult
+): PublicComponentStatus => {
+	if (liveness === 'unhealthy') return 'outage';
+	if (liveness === 'healthy' && readiness === 'healthy') return 'operational';
+	if (liveness === 'unknown' && readiness === 'unknown') return 'unknown';
+	return 'degraded';
+};
+
+const gatewayStatus = (health: ProbeResult): PublicComponentStatus =>
+	health === 'healthy' ? 'operational' : health === 'unhealthy' ? 'outage' : 'unknown';
+
+const overallStatus = (components: ReadonlyArray<PublicComponentStatus>): PublicComponentStatus => {
+	if (components.includes('outage')) return 'outage';
+	if (components.every((status) => status === 'operational')) return 'operational';
+	if (components.every((status) => status === 'unknown')) return 'unknown';
+	return 'degraded';
+};
+
+export const collectPublicStatus = async (
+	input: PublicStatusInput,
+	dependencies: PublicStatusDependencies = {}
+): Promise<PublicStatusSnapshot> => {
+	const controlPlaneOrigin = safeProbeOrigin(input.controlPlaneUrl, input.production);
+	const gatewayOrigin = safeProbeOrigin(input.gatewayUrl, input.production);
+	const fetchImplementation = dependencies.fetch ?? globalThis.fetch;
+	const timeoutMs = dependencies.timeoutMs ?? STATUS_PROBE_TIMEOUT_MS;
+	const boundedTimeout =
+		Number.isSafeInteger(timeoutMs) && timeoutMs > 0
+			? Math.min(timeoutMs, STATUS_PROBE_TIMEOUT_MS)
+			: STATUS_PROBE_TIMEOUT_MS;
+
+	const [liveness, readiness, gatewayHealth] = await Promise.all([
+		controlPlaneOrigin
+			? probe(controlPlaneOrigin, '/healthz', fetchImplementation, boundedTimeout)
+			: Promise.resolve<ProbeResult>('unknown'),
+		controlPlaneOrigin
+			? probe(controlPlaneOrigin, '/readyz', fetchImplementation, boundedTimeout)
+			: Promise.resolve<ProbeResult>('unknown'),
+		gatewayOrigin
+			? probe(gatewayOrigin, '/healthz', fetchImplementation, boundedTimeout)
+			: Promise.resolve<ProbeResult>('unknown')
+	]);
+	const components = {
+		control_plane: controlPlaneStatus(liveness, readiness),
+		gateway: gatewayStatus(gatewayHealth)
+	} as const;
+	return {
+		status: overallStatus([components.control_plane, components.gateway]),
+		components,
+		checked_at: (dependencies.now ?? (() => new Date()))().toISOString()
+	};
+};

--- a/apps/web/src/lib/terminal.ts
+++ b/apps/web/src/lib/terminal.ts
@@ -12,6 +12,10 @@ export interface TerminalHandle {
 export interface TerminalOptions {
 	host: HTMLDivElement;
 	machineId: string;
+	connection?: {
+		readonly url: string;
+		readonly protocols?: string | string[] | readonly string[];
+	};
 	fontSize?: number;
 	theme?: Record<string, string>;
 	bannerText: string;
@@ -19,8 +23,9 @@ export interface TerminalOptions {
 }
 
 /**
- * Set up an xterm.js terminal connected to a machine's serial console via
- * WebSocket, including the copy-selection key handler and resize listener.
+ * Set up an xterm.js terminal connected to a machine PTY via WebSocket,
+ * including the copy-selection key handler and resize listener. Managed hosts
+ * terminate this in the restart-safe guest agent; local mode uses serial.
  * Returns handles for cleanup.
  */
 export async function setupTerminal(opts: TerminalOptions): Promise<TerminalHandle> {
@@ -50,7 +55,9 @@ export async function setupTerminal(opts: TerminalOptions): Promise<TerminalHand
 	const onResize = () => fit.fit();
 	window.addEventListener('resize', onResize);
 
-	const ws = new WebSocket(wsUrl(`/v1/machines/${opts.machineId}/tty`));
+	const ws = opts.connection
+		? new WebSocket(opts.connection.url, opts.connection.protocols as string | string[] | undefined)
+		: new WebSocket(wsUrl(`/v1/machines/${opts.machineId}/tty`));
 	ws.binaryType = 'arraybuffer';
 	const enc = new TextEncoder();
 

--- a/apps/web/src/lib/vnc.ts
+++ b/apps/web/src/lib/vnc.ts
@@ -9,6 +9,10 @@ export interface VncHandle {
 export interface VncOptions {
 	screen: HTMLDivElement;
 	machineId: string;
+	connection?: {
+		readonly url: string;
+		readonly protocols?: readonly string[];
+	};
 	viewOnly?: boolean;
 	qualityLevel?: number;
 	compressionLevel?: number;
@@ -32,8 +36,10 @@ export async function connectVnc(
 
 	teardownScreen(opts.screen);
 
-	const url = wsUrl(`/v1/machines/${opts.machineId}/vnc`);
-	const rfb = new RFB(opts.screen, url, {});
+	const url = opts.connection?.url ?? wsUrl(`/v1/machines/${opts.machineId}/vnc`);
+	const rfb = new RFB(opts.screen, url, {
+		wsProtocols: opts.connection?.protocols ? [...opts.connection.protocols] : undefined
+	});
 	rfb.scaleViewport = true;
 	rfb.resizeSession = false;
 	rfb.background = '#000';

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -35,6 +35,10 @@
 	>
 	<div class="flex items-center gap-5">
 		<a href={resolve('/docs')} class="text-ink-subtle transition-colors hover:text-ink">Docs</a>
+		<a href={resolve('/status')} class="text-ink-subtle transition-colors hover:text-ink">Status</a>
+		<a href={resolve('/dashboard')} class="text-ink-subtle transition-colors hover:text-ink"
+			>Cloud</a
+		>
 		<a
 			href="https://github.com/boringcomputers/nehemiah"
 			target="_blank"

--- a/apps/web/src/routes/dashboard/+layout.svelte
+++ b/apps/web/src/routes/dashboard/+layout.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { onMount } from 'svelte';
+	import { loadClerk, type ClerkLike } from '$lib/clerk';
+	import {
+		dashboardApi,
+		organizationForDashboard,
+		selectedOrganization,
+		selectOrganization
+	} from '$lib/nehemiah-client';
+
+	let { children } = $props();
+	type Organization = { id: string; name: string; slug: string };
+	let clerk = $state<ClerkLike>();
+	let loading = $state(true);
+	let error = $state('');
+	let organizations = $state<Organization[]>([]);
+	let organizationId = $state('');
+	let organizationLoading = $state(false);
+	let organizationError = $state('');
+	let bootstrappedUserId = '';
+	let bootstrapGeneration = 0;
+
+	async function bootstrapOrganization(loaded: ClerkLike) {
+		const userId = loaded.user?.id;
+		if (!userId) return;
+		const generation = ++bootstrapGeneration;
+		organizationLoading = true;
+		organizationError = '';
+		try {
+			const result = await dashboardApi<{ organizations: Organization[] }>(
+				'/v1/organizations',
+				{},
+				undefined
+			);
+			if (generation !== bootstrapGeneration || loaded.user?.id !== userId) return;
+			organizations = result.organizations;
+			organizationId = organizationForDashboard(organizations, selectedOrganization()) ?? '';
+			if (organizationId) selectOrganization(organizationId);
+			bootstrappedUserId = userId;
+		} catch (cause) {
+			if (generation !== bootstrapGeneration) return;
+			organizationError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			if (generation === bootstrapGeneration) organizationLoading = false;
+		}
+	}
+
+	function changeOrganization(id: string) {
+		if (!organizations.some((organization) => organization.id === id)) return;
+		organizationId = id;
+		selectOrganization(id);
+	}
+
+	function resetOrganization() {
+		bootstrapGeneration += 1;
+		organizations = [];
+		organizationId = '';
+		organizationLoading = false;
+		organizationError = '';
+		bootstrappedUserId = '';
+	}
+
+	function retryOrganization() {
+		if (clerk) void bootstrapOrganization(clerk);
+	}
+
+	onMount(() => {
+		let mounted = true;
+		let unsubscribe: (() => void) | undefined;
+		void loadClerk()
+			.then((loaded) => {
+				if (!mounted) return;
+				clerk = loaded;
+				loading = false;
+				unsubscribe = loaded.addListener(() => {
+					if (!mounted) return;
+					clerk = loaded;
+					const userId = loaded.user?.id;
+					if (!userId) resetOrganization();
+					else if (userId !== bootstrappedUserId && !organizationLoading) {
+						void bootstrapOrganization(loaded);
+					}
+				});
+				if (loaded.user) void bootstrapOrganization(loaded);
+			})
+			.catch((cause) => {
+				if (!mounted) return;
+				error = cause instanceof Error ? cause.message : String(cause);
+				loading = false;
+			});
+		return () => {
+			mounted = false;
+			bootstrapGeneration += 1;
+			unsubscribe?.();
+		};
+	});
+
+	const links = [
+		['Overview', '/dashboard'],
+		['Machines', '/dashboard/machines'],
+		['Projects', '/dashboard/projects'],
+		['API keys', '/dashboard/api-keys'],
+		['Templates', '/dashboard/templates'],
+		['Volumes', '/dashboard/volumes'],
+		['Usage', '/dashboard/usage']
+	] as const;
+</script>
+
+<svelte:head><title>Dashboard · Nehemiah</title></svelte:head>
+
+<main class="mx-auto min-h-screen max-w-6xl px-5 pt-20 pb-16 text-ink">
+	{#if loading}
+		<p class="font-mono text-sm text-ink-muted">Loading dashboard…</p>
+	{:else if error}
+		<div class="rounded-geist border border-line bg-surface p-6">
+			<h1 class="text-lg font-semibold">Dashboard unavailable</h1>
+			<p class="mt-2 text-sm text-ink-muted">{error}</p>
+		</div>
+	{:else if !clerk?.user}
+		<div
+			class="mx-auto mt-20 max-w-md rounded-geist-lg border border-line bg-surface p-8 text-center"
+		>
+			<h1 class="text-xl font-semibold">Nehemiah Cloud</h1>
+			<p class="mt-2 text-sm text-ink-muted">
+				Sign in to manage projects, machines, templates, volumes, and usage.
+			</p>
+			<button
+				class="mt-6 rounded-geist bg-ink px-4 py-2 text-sm font-semibold text-black"
+				onclick={() => clerk?.openSignIn()}>Sign in</button
+			>
+		</div>
+	{:else}
+		<header
+			class="mb-8 flex flex-wrap items-center justify-between gap-4 border-b border-line pb-5"
+		>
+			<div>
+				<div class="font-semibold">Nehemiah Cloud</div>
+				<div class="text-xs text-ink-faint">{clerk.user.fullName ?? clerk.user.id}</div>
+			</div>
+			<div class="flex items-center gap-3">
+				{#if organizations.length > 1}
+					<label class="sr-only" for="dashboard-organization">Organization</label>
+					<select
+						id="dashboard-organization"
+						class="max-w-56 rounded-geist border border-line bg-black px-2 py-1.5 text-xs"
+						value={organizationId}
+						onchange={(event) => changeOrganization(event.currentTarget.value)}
+					>
+						{#each organizations as organization (organization.id)}
+							<option value={organization.id}>{organization.name}</option>
+						{/each}
+					</select>
+				{:else if organizations.length === 1}
+					<span class="text-xs text-ink-muted">{organizations[0].name}</span>
+				{/if}
+				<button class="text-xs text-ink-muted hover:text-ink" onclick={() => void clerk?.signOut()}
+					>Sign out</button
+				>
+			</div>
+		</header>
+		{#if organizationLoading}
+			<p class="font-mono text-sm text-ink-muted">Loading organization…</p>
+		{:else if organizationError}
+			<div class="rounded-geist border border-red-900/50 bg-red-950/20 p-5">
+				<p class="text-sm text-red-200">{organizationError}</p>
+				<button
+					class="mt-3 text-xs font-semibold text-red-100 underline"
+					onclick={retryOrganization}>Retry</button
+				>
+			</div>
+		{:else if !organizationId}
+			<div class="rounded-geist border border-line bg-surface p-6">
+				<h1 class="text-lg font-semibold">No organization assigned</h1>
+				<p class="mt-2 text-sm text-ink-muted">
+					Ask a Nehemiah administrator to add this account to an organization.
+				</p>
+			</div>
+		{:else}
+			<div class="grid gap-8 md:grid-cols-[170px_1fr]">
+				<nav class="flex gap-2 overflow-x-auto md:flex-col">
+					{#each links as [label, href] (href)}<a
+							class="whitespace-nowrap rounded-geist px-3 py-2 text-sm text-ink-muted hover:bg-surface hover:text-ink"
+							href={resolve(href)}>{label}</a
+						>{/each}
+				</nav>
+				{#key organizationId}<section>{@render children()}</section>{/key}
+			</div>
+		{/if}
+	{/if}
+</main>

--- a/apps/web/src/routes/dashboard/+page.svelte
+++ b/apps/web/src/routes/dashboard/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dashboardApi, selectOrganization, selectedOrganization } from '$lib/nehemiah-client';
+
+	type Organization = { id: string; name: string; slug: string };
+	let organizations = $state<Organization[]>([]);
+	let organizationId = $state('');
+	let machineCount = $state(0);
+	let error = $state('');
+
+	async function load() {
+		try {
+			const result = await dashboardApi<{ organizations: Organization[] }>(
+				'/v1/organizations',
+				{},
+				undefined
+			);
+			organizations = result.organizations;
+			organizationId = selectedOrganization() ?? organizations[0]?.id ?? '';
+			if (organizationId) {
+				selectOrganization(organizationId);
+				machineCount = (
+					await dashboardApi<{ machines: unknown[] }>('/v1/machines', {}, organizationId)
+				).machines.length;
+			}
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	async function changeOrganization(id: string) {
+		organizationId = id;
+		selectOrganization(id);
+		await load();
+	}
+
+	onMount(() => void load());
+</script>
+
+<h1 class="text-xl font-semibold">Overview</h1>
+{#if error}<p
+		class="mt-4 rounded-geist border border-red-900/50 bg-red-950/20 p-3 text-sm text-red-300"
+	>
+		{error}
+	</p>{/if}
+<label class="mt-6 block max-w-sm text-xs text-ink-muted"
+	>Organization
+	<select
+		class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+		value={organizationId}
+		onchange={(event) => void changeOrganization(event.currentTarget.value)}
+	>
+		{#each organizations as organization (organization.id)}<option value={organization.id}
+				>{organization.name}</option
+			>{/each}
+	</select>
+</label>
+<div class="mt-8 grid gap-4 sm:grid-cols-3">
+	<div class="rounded-geist border border-line bg-surface p-5">
+		<div class="text-2xl font-semibold">{machineCount}</div>
+		<div class="mt-1 text-xs text-ink-muted">Machines</div>
+	</div>
+	<div class="rounded-geist border border-line bg-surface p-5">
+		<div class="text-2xl font-semibold">Private beta</div>
+		<div class="mt-1 text-xs text-ink-muted">Plan</div>
+	</div>
+	<div class="rounded-geist border border-line bg-surface p-5">
+		<div class="text-2xl font-semibold">ca-tor-1</div>
+		<div class="mt-1 text-xs text-ink-muted">Region</div>
+	</div>
+</div>

--- a/apps/web/src/routes/dashboard/api-keys/+page.svelte
+++ b/apps/web/src/routes/dashboard/api-keys/+page.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dashboardApi } from '$lib/nehemiah-client';
+
+	type Project = { id: string; name: string };
+	type ApiKey = {
+		id: string;
+		project_id?: string;
+		name: string;
+		prefix: string;
+		scopes: string[];
+		expires_at?: string;
+		last_used_at?: string;
+		disabled_at?: string;
+		revoked_at?: string;
+	};
+	const allScopes = [
+		'machines:read',
+		'machines:write',
+		'templates:read',
+		'templates:write',
+		'volumes:read',
+		'volumes:write',
+		'billing:read'
+	] as const;
+	let projects = $state<Project[]>([]);
+	let keys = $state<ApiKey[]>([]);
+	let projectId = $state('');
+	let name = $state('CLI');
+	let scopes = $state<string[]>(['machines:read', 'machines:write', 'templates:read']);
+	let expiresOn = $state('');
+	let secret = $state('');
+	let error = $state('');
+	let pendingKeyId = $state('');
+
+	async function load() {
+		try {
+			projects = (await dashboardApi<{ projects: Project[] }>('/v1/projects')).projects;
+			projectId ||= projects[0]?.id ?? '';
+			keys = (await dashboardApi<{ api_keys: ApiKey[] }>('/v1/api-keys')).api_keys;
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	onMount(() => void load());
+
+	async function create() {
+		secret = '';
+		error = '';
+		try {
+			if (scopes.length === 0) throw new Error('Select at least one scope.');
+			const created = await dashboardApi<{ key: string }>('/v1/api-keys', {
+				method: 'POST',
+				body: JSON.stringify({
+					name,
+					project_id: projectId || undefined,
+					scopes,
+					expires_at: expiresOn ? new Date(`${expiresOn}T23:59:59.999Z`).toISOString() : undefined
+				})
+			});
+			secret = created.key;
+			await load();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	async function revoke(id: string) {
+		error = '';
+		pendingKeyId = id;
+		try {
+			await dashboardApi(`/v1/api-keys/${encodeURIComponent(id)}`, { method: 'DELETE' });
+			await load();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			pendingKeyId = '';
+		}
+	}
+
+	async function setDisabled(id: string, disabled: boolean) {
+		error = '';
+		pendingKeyId = id;
+		try {
+			await dashboardApi(
+				`/v1/api-keys/${encodeURIComponent(id)}/${disabled ? 'disable' : 'enable'}`,
+				{ method: 'POST' }
+			);
+			await load();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			pendingKeyId = '';
+		}
+	}
+
+	async function rotate(id: string) {
+		error = '';
+		secret = '';
+		pendingKeyId = id;
+		try {
+			const replacement = await dashboardApi<{ key: string }>(
+				`/v1/api-keys/${encodeURIComponent(id)}/rotate`,
+				{ method: 'POST' }
+			);
+			secret = replacement.key;
+			await load();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			pendingKeyId = '';
+		}
+	}
+</script>
+
+<h1 class="text-xl font-semibold">API keys</h1>
+<p class="mt-2 text-sm text-ink-muted">
+	Secrets are hashed with Argon2id and shown once. Put automation keys in a secret manager.
+</p>
+<form
+	class="mt-6 grid max-w-xl gap-3 rounded-geist border border-line bg-surface p-5"
+	onsubmit={(event) => {
+		event.preventDefault();
+		void create();
+	}}
+>
+	<input
+		class="rounded-geist border border-line bg-black px-3 py-2 text-sm"
+		bind:value={name}
+		required
+	/>
+	<select class="rounded-geist border border-line bg-black px-3 py-2 text-sm" bind:value={projectId}
+		><option value="">All projects</option>{#each projects as project (project.id)}<option
+				value={project.id}>{project.name}</option
+			>{/each}</select
+	>
+	<label class="grid gap-1 text-xs text-ink-muted">
+		Expires on (optional)
+		<input
+			class="rounded-geist border border-line bg-black px-3 py-2 text-sm text-ink"
+			type="date"
+			min={new Date().toISOString().slice(0, 10)}
+			bind:value={expiresOn}
+		/>
+	</label>
+	<fieldset class="grid gap-2 rounded-geist border border-line p-3">
+		<legend class="px-1 text-xs text-ink-muted">Scopes</legend>
+		<div class="grid gap-2 sm:grid-cols-2">
+			{#each allScopes as scope (scope)}
+				<label class="flex items-center gap-2 font-mono text-xs">
+					<input type="checkbox" value={scope} bind:group={scopes} />
+					{scope}
+				</label>
+			{/each}
+		</div>
+	</fieldset>
+	<button class="rounded-geist bg-ink px-3 py-2 text-sm font-semibold text-black">Create key</button
+	>
+</form>
+{#if secret}<div class="mt-5 rounded-geist border border-amber-700/50 bg-amber-950/20 p-4">
+		<div class="text-xs font-semibold text-amber-200">
+			Copy this now — it will not be shown again.
+		</div>
+		<code class="mt-2 block break-all text-sm text-amber-100">{secret}</code>
+	</div>{/if}
+{#if error}<p class="mt-4 text-sm text-red-300">{error}</p>{/if}
+<div class="mt-6 divide-y divide-line rounded-geist border border-line">
+	{#each keys as key (key.id)}
+		<div class="flex items-center justify-between gap-4 p-4">
+			<div>
+				<div class="font-medium">{key.name}</div>
+				<div class="font-mono text-xs text-ink-faint">{key.prefix} · {key.scopes.join(', ')}</div>
+				<div class="mt-1 text-xs text-ink-faint">
+					{key.project_id ? `Project ${key.project_id}` : 'All projects'}
+					{key.expires_at ? ` · expires ${new Date(key.expires_at).toLocaleString()}` : ''}
+					{key.last_used_at ? ` · last used ${new Date(key.last_used_at).toLocaleString()}` : ''}
+					{key.disabled_at ? ` · disabled ${new Date(key.disabled_at).toLocaleString()}` : ''}
+				</div>
+			</div>
+			{#if key.revoked_at}
+				<span class="text-xs text-ink-faint">Revoked</span>
+			{:else}
+				<div class="flex items-center gap-3">
+					{#if key.disabled_at}
+						<button
+							class="text-xs text-ink-muted hover:text-ink disabled:opacity-50"
+							disabled={pendingKeyId === key.id}
+							onclick={() => void setDisabled(key.id, false)}>Enable</button
+						>
+					{:else}
+						<button
+							class="text-xs text-ink-muted hover:text-ink disabled:opacity-50"
+							disabled={pendingKeyId === key.id}
+							onclick={() => void setDisabled(key.id, true)}>Disable</button
+						>
+						<button
+							class="text-xs text-ink-muted hover:text-ink disabled:opacity-50"
+							disabled={pendingKeyId === key.id}
+							onclick={() => void rotate(key.id)}>Rotate</button
+						>
+					{/if}
+					<button
+						class="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
+						disabled={pendingKeyId === key.id}
+						onclick={() => void revoke(key.id)}>Revoke</button
+					>
+				</div>
+			{/if}
+		</div>
+	{:else}<p class="p-4 text-sm text-ink-muted">No API keys yet.</p>{/each}
+</div>

--- a/apps/web/src/routes/dashboard/api/[...path]/+server.ts
+++ b/apps/web/src/routes/dashboard/api/[...path]/+server.ts
@@ -1,0 +1,88 @@
+import { env } from '$env/dynamic/private';
+import { dev } from '$app/environment';
+import { controlPlaneOrigin } from '$lib/server/control-plane-origin';
+import type { RequestHandler } from './$types';
+
+const maximumBodyBytes = 1 << 20;
+
+const boundedBody = async (request: Request): Promise<Uint8Array | undefined> => {
+	if (!request.body) return undefined;
+	const reader = request.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		total += value.byteLength;
+		if (total > maximumBodyBytes) {
+			await reader.cancel();
+			throw new Error('body_too_large');
+		}
+		chunks.push(value);
+	}
+	const output = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		output.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return output;
+};
+
+const proxy: RequestHandler = async ({ request, params, url, fetch }) => {
+	const upstream = controlPlaneOrigin(env.PRIVATE_NEHEMIAH_URL, dev);
+	if (!upstream) return Response.json({ title: 'dashboard_not_configured' }, { status: 503 });
+	const path = params.path ?? '';
+	// Only the public API namespace is proxyable. Reject percent escapes and dot
+	// segments instead of relying on URL normalization, which can turn a doubly
+	// encoded dashboard path into an internal control-plane path.
+	if (!/^v1(?:\/[A-Za-z0-9_-]+)*$/.test(path)) {
+		return Response.json({ title: 'invalid_proxy_path' }, { status: 400 });
+	}
+	const authorization = request.headers.get('authorization');
+	if (!authorization?.startsWith('Bearer ')) {
+		return Response.json({ title: 'unauthorized' }, { status: 401 });
+	}
+	const headers = new Headers({ authorization, accept: 'application/json' });
+	for (const name of ['content-type', 'idempotency-key', 'x-nehemiah-organization-id']) {
+		const value = request.headers.get(name);
+		if (value) headers.set(name, value);
+	}
+	const declaredLength = Number(request.headers.get('content-length'));
+	if (Number.isFinite(declaredLength) && declaredLength > maximumBodyBytes) {
+		return Response.json({ title: 'request_too_large' }, { status: 413 });
+	}
+	let body: Uint8Array | undefined;
+	if (request.method !== 'GET' && request.method !== 'HEAD') {
+		try {
+			body = await boundedBody(request);
+		} catch {
+			return Response.json({ title: 'request_too_large' }, { status: 413 });
+		}
+	}
+	const response = await fetch(`${upstream}/${path}${url.search}`, {
+		method: request.method,
+		headers,
+		body: body as BodyInit | undefined,
+		signal: request.signal
+	});
+	const outgoing = new Headers();
+	for (const name of [
+		'content-type',
+		'x-request-id',
+		'retry-after',
+		'ratelimit-limit',
+		'ratelimit-remaining',
+		'ratelimit-reset'
+	]) {
+		const value = response.headers.get(name);
+		if (value) outgoing.set(name, value);
+	}
+	outgoing.set('cache-control', 'no-store');
+	return new Response(response.body, { status: response.status, headers: outgoing });
+};
+
+export const GET = proxy;
+export const POST = proxy;
+export const DELETE = proxy;
+export const PATCH = proxy;

--- a/apps/web/src/routes/dashboard/device/+page.svelte
+++ b/apps/web/src/routes/dashboard/device/+page.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { dashboardApi } from '$lib/nehemiah-client';
+
+	type Project = { id: string; name: string };
+	type DeviceRequest = {
+		client_id: string;
+		scopes: string[];
+		expires_at: string;
+		status: 'pending';
+	};
+
+	let userCode = $state('');
+	let request = $state<DeviceRequest>();
+	let projects = $state<Project[]>([]);
+	let projectId = $state('');
+	let scopes = $state<string[]>([]);
+	let loading = $state(true);
+	let deciding = $state(false);
+	let decision = $state<'approved' | 'denied'>();
+	let error = $state('');
+
+	async function inspect() {
+		loading = true;
+		error = '';
+		try {
+			userCode = (page.url.searchParams.get('user_code') ?? '').toUpperCase();
+			if (!/^[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}$/.test(userCode)) {
+				throw new Error('Enter the eight-character code shown by the CLI.');
+			}
+			const [inspected, projectList] = await Promise.all([
+				dashboardApi<DeviceRequest>('/v1/auth/device/inspect', {
+					method: 'POST',
+					body: JSON.stringify({ user_code: userCode })
+				}),
+				dashboardApi<{ projects: Project[] }>('/v1/projects')
+			]);
+			request = inspected;
+			scopes = [...inspected.scopes];
+			projects = projectList.projects;
+			projectId = projects[0]?.id ?? '';
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function decide(next: 'approve' | 'deny') {
+		if (next === 'approve' && (!projectId || scopes.length === 0)) {
+			error = 'Choose a project and at least one requested scope.';
+			return;
+		}
+		deciding = true;
+		error = '';
+		try {
+			await dashboardApi('/v1/auth/device/authorize', {
+				method: 'POST',
+				body: JSON.stringify({
+					user_code: userCode,
+					decision: next,
+					...(next === 'approve' ? { project_id: projectId, scopes } : {})
+				})
+			});
+			decision = next === 'approve' ? 'approved' : 'denied';
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			deciding = false;
+		}
+	}
+
+	onMount(() => void inspect());
+</script>
+
+<svelte:head><title>Authorize CLI · Nehemiah</title></svelte:head>
+
+<div class="max-w-xl">
+	<h1 class="text-xl font-semibold">Authorize the CLI</h1>
+	<p class="mt-2 text-sm text-ink-muted">
+		Only approve if <code class="font-mono text-ink">{userCode || 'the code'}</code> matches the code
+		shown in your terminal.
+	</p>
+
+	{#if loading}
+		<p class="mt-6 font-mono text-sm text-ink-muted">Checking authorization request…</p>
+	{:else if decision}
+		<div class="mt-6 rounded-geist border border-line bg-surface p-5">
+			<h2 class="font-semibold">Request {decision}</h2>
+			<p class="mt-2 text-sm text-ink-muted">You can close this page and return to the CLI.</p>
+		</div>
+	{:else if request}
+		<div class="mt-6 grid gap-4 rounded-geist border border-line bg-surface p-5">
+			<div>
+				<div class="text-xs text-ink-faint">Client</div>
+				<div class="mt-1 font-mono text-sm">{request.client_id}</div>
+			</div>
+			<label class="grid gap-1 text-xs text-ink-muted">
+				Project
+				<select
+					class="rounded-geist border border-line bg-black px-3 py-2 text-sm text-ink"
+					bind:value={projectId}
+					required
+				>
+					{#each projects as project (project.id)}
+						<option value={project.id}>{project.name}</option>
+					{/each}
+				</select>
+			</label>
+			<fieldset class="grid gap-2 rounded-geist border border-line p-3">
+				<legend class="px-1 text-xs text-ink-muted">Explicitly allowed scopes</legend>
+				{#each request.scopes as scope (scope)}
+					<label class="flex items-center gap-2 font-mono text-xs">
+						<input type="checkbox" value={scope} bind:group={scopes} />
+						{scope}
+					</label>
+				{/each}
+			</fieldset>
+			<p class="text-xs text-ink-faint">
+				This code expires {new Date(request.expires_at).toLocaleString()}.
+			</p>
+			<div class="flex gap-3">
+				<button
+					class="rounded-geist bg-ink px-4 py-2 text-sm font-semibold text-black disabled:opacity-50"
+					disabled={deciding || !projectId || scopes.length === 0}
+					onclick={() => void decide('approve')}>Approve selected access</button
+				>
+				<button
+					class="rounded-geist border border-line px-4 py-2 text-sm text-red-200 disabled:opacity-50"
+					disabled={deciding}
+					onclick={() => void decide('deny')}>Deny</button
+				>
+			</div>
+		</div>
+	{/if}
+	{#if error}<p class="mt-4 text-sm text-red-300">{error}</p>{/if}
+</div>

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -67,6 +67,7 @@
 	let connectionGeneration = 0;
 	let refreshInFlight = $state(false);
 	let refreshGeneration = 0;
+	let previewGeneration = 0;
 
 	const selectedMachine = $derived(machines.find((machine) => machine.id === selectedMachineId));
 	const isTerminal = (machine: Machine) => ['stopped', 'failed', 'lost'].includes(machine.state);
@@ -145,6 +146,7 @@
 
 	async function changeProject(id: string) {
 		disconnectConnection();
+		previewGeneration += 1;
 		projectId = id;
 		machines = [];
 		selectedMachineId = '';
@@ -360,15 +362,16 @@
 		const popup = window.open('about:blank', '_blank');
 		if (popup) popup.opener = null;
 		setBusy(id, 'Opening preview…');
-		// connectionGeneration is bumped on every project switch (via
-		// disconnectConnection), so this invalidates a pending preview even across an
-		// A -> B -> A round-trip. Capture the port too, so a later port change cannot
-		// invalidate a session that was validly issued for the original port.
-		const generation = connectionGeneration;
+		// previewGeneration is bumped only on project switch (separate from
+		// terminal/desktop connection teardown), so a pending preview is invalidated
+		// across an A -> B -> A round-trip but not by starting a TTY/VNC session.
+		// Capture the port too, so a later port change cannot invalidate a session
+		// that was validly issued for the original port.
+		const generation = previewGeneration;
 		const requestedPort = previewPort;
 		try {
 			const session = await issueSession(id, 'preview');
-			if (generation !== connectionGeneration) {
+			if (generation !== previewGeneration) {
 				popup?.close();
 				return;
 			}

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -403,6 +403,9 @@
 		return () => {
 			window.clearInterval(interval);
 			disconnectConnection();
+			// Invalidate any pending preview so a session that resolves after the page
+			// is torn down does not publish a URL or redirect the already-opened popup.
+			previewGeneration += 1;
 		};
 	});
 </script>

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -360,19 +360,22 @@
 		const popup = window.open('about:blank', '_blank');
 		if (popup) popup.opener = null;
 		setBusy(id, 'Opening preview…');
-		const requestedProjectId = projectId;
+		// connectionGeneration is bumped on every project switch (via
+		// disconnectConnection), so this invalidates a pending preview even across an
+		// A -> B -> A round-trip. Capture the port too, so a later port change cannot
+		// invalidate a session that was validly issued for the original port.
+		const generation = connectionGeneration;
+		const requestedPort = previewPort;
 		try {
 			const session = await issueSession(id, 'preview');
-			// Abandon a preview the user has navigated away from (e.g. project switch)
-			// rather than publishing its URL or redirecting the popup.
-			if (requestedProjectId !== projectId) {
+			if (generation !== connectionGeneration) {
 				popup?.close();
 				return;
 			}
-			previewLink = machinePreviewUrl(session, id, previewPort);
+			previewLink = machinePreviewUrl(session, id, requestedPort);
 			if (popup) {
 				popup.location.replace(previewLink);
-				actionNotice = `Preview opened on port ${previewPort}. The session expires in ${session.expires_in} seconds.`;
+				actionNotice = `Preview opened on port ${requestedPort}. The session expires in ${session.expires_in} seconds.`;
 			} else {
 				actionNotice = 'Your browser blocked the new tab. Use the preview link below.';
 			}

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -66,6 +66,7 @@
 	let vncHandle: VncHandle | null | undefined;
 	let connectionGeneration = 0;
 	let refreshInFlight = $state(false);
+	let refreshGeneration = 0;
 
 	const selectedMachine = $derived(machines.find((machine) => machine.id === selectedMachineId));
 	const isTerminal = (machine: Machine) => ['stopped', 'failed', 'lost'].includes(machine.state);
@@ -98,22 +99,30 @@
 	}
 
 	async function refreshMachines(silent = false) {
-		if (!projectId || refreshInFlight) return;
+		if (!projectId) return;
+		// A newer refresh (e.g. after a project switch) supersedes this one, so a
+		// stale in-flight response is never applied under a different selection.
+		const generation = ++refreshGeneration;
+		const requestedProjectId = projectId;
 		refreshInFlight = true;
 		if (!silent) loadError = '';
 		try {
-			machines = (
+			const result = (
 				await dashboardApi<{ machines: Machine[] }>(
-					`/v1/machines?project_id=${encodeURIComponent(projectId)}`
+					`/v1/machines?project_id=${encodeURIComponent(requestedProjectId)}`
 				)
 			).machines;
+			if (generation !== refreshGeneration || requestedProjectId !== projectId) return;
+			machines = result;
 			if (selectedMachineId && !machines.some((machine) => machine.id === selectedMachineId)) {
 				selectedMachineId = '';
 			}
 		} catch (cause) {
-			if (!silent) loadError = cause instanceof Error ? cause.message : String(cause);
+			if (generation === refreshGeneration && !silent) {
+				loadError = cause instanceof Error ? cause.message : String(cause);
+			}
 		} finally {
-			refreshInFlight = false;
+			if (generation === refreshGeneration) refreshInFlight = false;
 		}
 	}
 

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -360,8 +360,15 @@
 		const popup = window.open('about:blank', '_blank');
 		if (popup) popup.opener = null;
 		setBusy(id, 'Opening preview…');
+		const requestedProjectId = projectId;
 		try {
 			const session = await issueSession(id, 'preview');
+			// Abandon a preview the user has navigated away from (e.g. project switch)
+			// rather than publishing its URL or redirecting the popup.
+			if (requestedProjectId !== projectId) {
+				popup?.close();
+				return;
+			}
 			previewLink = machinePreviewUrl(session, id, previewPort);
 			if (popup) {
 				popup.location.replace(previewLink);

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -68,6 +68,12 @@
 	let refreshInFlight = $state(false);
 	let refreshGeneration = 0;
 	let previewGeneration = 0;
+	// Any machine-selection change invalidates a pending preview, including an
+	// A -> B -> A round-trip that a plain id comparison cannot detect.
+	$effect(() => {
+		void selectedMachineId;
+		previewGeneration += 1;
+	});
 
 	const selectedMachine = $derived(machines.find((machine) => machine.id === selectedMachineId));
 	const isTerminal = (machine: Machine) => ['stopped', 'failed', 'lost'].includes(machine.state);
@@ -371,10 +377,10 @@
 		const requestedPort = previewPort;
 		try {
 			const session = await issueSession(id, 'preview');
-			// Abandon the preview if the user switched projects (previewGeneration) or
-			// selected a different machine. Connecting a TTY/VNC session leaves the
-			// selection unchanged, so a valid pending preview is not cancelled.
-			if (generation !== previewGeneration || id !== selectedMachineId) {
+			// previewGeneration is bumped on project switch, any machine-selection
+			// change, and page teardown — but not by connecting a TTY/VNC session — so
+			// this abandons a stale preview without cancelling a still-valid one.
+			if (generation !== previewGeneration) {
 				popup?.close();
 				return;
 			}

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -1,0 +1,751 @@
+<script lang="ts">
+	import '@xterm/xterm/css/xterm.css';
+	import { onMount, tick } from 'svelte';
+	import {
+		dashboardApi,
+		machinePreviewUrl,
+		machineWebSocketSession,
+		type DashboardMachineSession
+	} from '$lib/nehemiah-client';
+	import { durableOperation } from '$lib/durable-operation';
+	import { setupTerminal, type TerminalHandle } from '$lib/terminal';
+	import { connectVnc, type VncHandle } from '$lib/vnc';
+
+	type Project = { id: string; name: string };
+	type Machine = {
+		id: string;
+		state: string;
+		ready: boolean;
+		region: string;
+		expires_at: string;
+		project_id: string;
+		template?: string;
+		network_policy?: {
+			mode: 'off' | 'allowlist';
+			hostnames: string[];
+			cidrs: string[];
+		};
+		failure_reason?: string;
+		resources?: { vcpus: number; memory_mb: number; disk_mb: number };
+	};
+	type Execution = {
+		stdout: string;
+		stderr: string;
+		exit_code: number | null;
+		timed_out: boolean;
+		duration_ms: number;
+	};
+
+	let projects = $state<Project[]>([]);
+	let projectId = $state('');
+	let machines = $state<Machine[]>([]);
+	let templateName = $state('python');
+	let ttlSeconds = $state(900);
+	let vcpus = $state(1);
+	let memoryMb = $state(512);
+	let diskMb = $state(5120);
+	let launching = $state(false);
+	let loading = $state(true);
+	let loadError = $state('');
+	let actionError = $state('');
+	let actionNotice = $state('');
+	let busy = $state<Record<string, string>>({});
+	let pendingDestroyId = $state('');
+	let selectedMachineId = $state('');
+	let extensionSeconds = $state(900);
+	let forkCount = $state(1);
+	let command = $state('uname -a');
+	let execution = $state<Execution>();
+	let previewPort = $state(3000);
+	let previewLink = $state('');
+	let connectionKind = $state<'tty' | 'vnc' | ''>('');
+	let connectionStatus = $state('');
+	let terminalHost = $state<HTMLDivElement>();
+	let vncScreen = $state<HTMLDivElement>();
+	let terminalHandle: TerminalHandle | undefined;
+	let vncHandle: VncHandle | null | undefined;
+	let connectionGeneration = 0;
+	let refreshInFlight = $state(false);
+
+	const selectedMachine = $derived(machines.find((machine) => machine.id === selectedMachineId));
+	const isTerminal = (machine: Machine) => ['stopped', 'failed', 'lost'].includes(machine.state);
+	const isBusy = (id: string) => Boolean(busy[id]);
+	const formatExpiry = (value: string) => {
+		const date = new Date(value);
+		return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+	};
+	function setBusy(id: string, action?: string) {
+		const next = { ...busy };
+		if (action) next[id] = action;
+		else delete next[id];
+		busy = next;
+	}
+
+	function clearActionFeedback() {
+		actionError = '';
+		actionNotice = '';
+		previewLink = '';
+	}
+
+	function disconnectConnection() {
+		connectionGeneration += 1;
+		terminalHandle?.cleanup();
+		vncHandle?.teardown();
+		terminalHandle = undefined;
+		vncHandle = undefined;
+		connectionKind = '';
+		connectionStatus = '';
+	}
+
+	async function refreshMachines(silent = false) {
+		if (!projectId || refreshInFlight) return;
+		refreshInFlight = true;
+		if (!silent) loadError = '';
+		try {
+			machines = (
+				await dashboardApi<{ machines: Machine[] }>(
+					`/v1/machines?project_id=${encodeURIComponent(projectId)}`
+				)
+			).machines;
+			if (selectedMachineId && !machines.some((machine) => machine.id === selectedMachineId)) {
+				selectedMachineId = '';
+			}
+		} catch (cause) {
+			if (!silent) loadError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			refreshInFlight = false;
+		}
+	}
+
+	async function initialize() {
+		loading = true;
+		loadError = '';
+		try {
+			projects = (await dashboardApi<{ projects: Project[] }>('/v1/projects')).projects;
+			if (!projects.some((project) => project.id === projectId)) {
+				projectId = projects[0]?.id ?? '';
+			}
+			if (projectId) await refreshMachines();
+			else machines = [];
+		} catch (cause) {
+			loadError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function changeProject(id: string) {
+		disconnectConnection();
+		projectId = id;
+		machines = [];
+		selectedMachineId = '';
+		execution = undefined;
+		clearActionFeedback();
+		await refreshMachines();
+	}
+
+	async function launch() {
+		if (!projectId) return;
+		launching = true;
+		clearActionFeedback();
+		let retryKey = '';
+		try {
+			const payload = {
+				project_id: projectId,
+				template: templateName.trim(),
+				ttl_seconds: ttlSeconds,
+				vcpus,
+				memory_mb: memoryMb,
+				disk_mb: diskMb,
+				network_policy: { mode: 'off', hostnames: [], cidrs: [] }
+			};
+			const operation = durableOperation(localStorage, `machine.create:${projectId}`, payload);
+			retryKey = operation.idempotencyKey;
+			const created = await dashboardApi<Machine>('/v1/machines', {
+				method: 'POST',
+				headers: { 'idempotency-key': operation.idempotencyKey },
+				body: JSON.stringify(payload)
+			});
+			operation.complete();
+			selectedMachineId = created.id;
+			actionNotice = `Machine ${created.id} was accepted and is ${created.ready ? 'ready' : 'starting'}.`;
+			await refreshMachines();
+		} catch (cause) {
+			actionError = `${cause instanceof Error ? cause.message : String(cause)}${retryKey ? ` Safe retry key: ${retryKey}` : ''}`;
+		} finally {
+			launching = false;
+		}
+	}
+
+	async function destroy(id: string) {
+		clearActionFeedback();
+		setBusy(id, 'Stopping…');
+		try {
+			await dashboardApi(`/v1/machines/${encodeURIComponent(id)}`, { method: 'DELETE' });
+			if (selectedMachineId === id) disconnectConnection();
+			pendingDestroyId = '';
+			actionNotice = `Machine ${id} is stopping.`;
+			await refreshMachines();
+		} catch (cause) {
+			actionError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	async function extend(id: string) {
+		clearActionFeedback();
+		setBusy(id, 'Extending…');
+		const payload = { ttl_seconds: extensionSeconds };
+		const operation = durableOperation(localStorage, `machine.extend:${id}`, payload);
+		try {
+			await dashboardApi(`/v1/machines/${encodeURIComponent(id)}/extend`, {
+				method: 'POST',
+				headers: { 'idempotency-key': operation.idempotencyKey },
+				body: JSON.stringify(payload)
+			});
+			operation.complete();
+			actionNotice = `Machine ${id} was extended by ${extensionSeconds} seconds.`;
+			await refreshMachines();
+		} catch (cause) {
+			actionError = `${cause instanceof Error ? cause.message : String(cause)} Safe retry key: ${operation.idempotencyKey}`;
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	async function exec(id: string) {
+		if (!command.trim()) return;
+		clearActionFeedback();
+		execution = undefined;
+		setBusy(id, 'Running…');
+		try {
+			execution = await dashboardApi<Execution>(`/v1/machines/${encodeURIComponent(id)}/exec`, {
+				method: 'POST',
+				body: JSON.stringify({ command, timeout_seconds: 30 })
+			});
+		} catch (cause) {
+			actionError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	async function fork(id: string) {
+		clearActionFeedback();
+		setBusy(id, 'Forking…');
+		const payload = { count: forkCount };
+		const requestOperation = durableOperation(localStorage, `machine.fork:${id}`, payload);
+		try {
+			const result = await dashboardApi<
+				| Machine
+				| {
+						machines: Machine[];
+						requested: number;
+						operation?: { id: string; state: string; idempotency_key?: string };
+				  }
+			>(`/v1/machines/${encodeURIComponent(id)}/fork`, {
+				method: 'POST',
+				headers: { 'idempotency-key': requestOperation.idempotencyKey },
+				body: JSON.stringify(payload)
+			});
+			const children = 'machines' in result ? result.machines : [result];
+			const forkOperation = 'operation' in result ? result.operation : undefined;
+			if (
+				forkOperation?.idempotency_key !== undefined &&
+				forkOperation.idempotency_key !== requestOperation.idempotencyKey
+			) {
+				throw new Error('Fork recovery identity did not match the submitted operation.');
+			}
+			actionNotice = forkOperation
+				? `Fork operation ${forkOperation.id} is ${forkOperation.state}; retry unchanged with key ${requestOperation.idempotencyKey}. All ${forkCount} children stay hidden until the batch is ready.`
+				: `Created ${children.length} ready fork${children.length === 1 ? '' : 's'} from ${id}.`;
+			if (!forkOperation) requestOperation.complete();
+			if (children[0]?.id) selectedMachineId = children[0].id;
+			await refreshMachines();
+		} catch (cause) {
+			actionError = `${cause instanceof Error ? cause.message : String(cause)} Safe retry key: ${requestOperation.idempotencyKey}`;
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	async function issueSession(
+		id: string,
+		capability: 'tty' | 'vnc' | 'preview'
+	): Promise<DashboardMachineSession> {
+		return dashboardApi(`/v1/machines/${encodeURIComponent(id)}/sessions`, {
+			method: 'POST',
+			body: JSON.stringify({
+				capabilities: [capability],
+				...(capability === 'preview' ? { port: previewPort } : {}),
+				ttl_seconds: 300
+			})
+		});
+	}
+
+	async function connectSession(id: string, capability: 'tty' | 'vnc') {
+		clearActionFeedback();
+		disconnectConnection();
+		const generation = connectionGeneration;
+		setBusy(id, 'Issuing session…');
+		try {
+			const session = await issueSession(id, capability);
+			if (generation !== connectionGeneration) return;
+			const connection = machineWebSocketSession(session, id, capability);
+			connectionKind = capability;
+			connectionStatus = 'Connecting…';
+			await tick();
+			if (generation !== connectionGeneration) return;
+			if (capability === 'tty') {
+				if (!terminalHost) throw new Error('The terminal could not be mounted');
+				const handle = await setupTerminal({
+					host: terminalHost,
+					machineId: id,
+					connection,
+					bannerText: '\r\nNehemiah Cloud terminal\r\n',
+					onClose: () => {
+						if (generation === connectionGeneration) connectionStatus = 'Session disconnected.';
+					}
+				});
+				if (generation !== connectionGeneration) {
+					handle.cleanup();
+					return;
+				}
+				terminalHandle = handle;
+				connectionStatus = `TTY session active · expires in ${session.expires_in} seconds`;
+			} else {
+				if (!vncScreen) throw new Error('The desktop could not be mounted');
+				const handle = await connectVnc(
+					{
+						screen: vncScreen,
+						machineId: id,
+						connection,
+						onConnect: () => {
+							if (generation === connectionGeneration) {
+								connectionStatus = `Desktop session active · expires in ${session.expires_in} seconds`;
+							}
+						},
+						onDisconnect: () => {
+							if (generation === connectionGeneration) connectionStatus = 'Session disconnected.';
+						}
+					},
+					() => generation !== connectionGeneration
+				);
+				if (generation !== connectionGeneration) {
+					handle?.teardown();
+					return;
+				}
+				vncHandle = handle;
+			}
+		} catch (cause) {
+			disconnectConnection();
+			actionError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	async function openPreview(id: string) {
+		clearActionFeedback();
+		const popup = window.open('about:blank', '_blank');
+		if (popup) popup.opener = null;
+		setBusy(id, 'Opening preview…');
+		try {
+			const session = await issueSession(id, 'preview');
+			previewLink = machinePreviewUrl(session, id, previewPort);
+			if (popup) {
+				popup.location.replace(previewLink);
+				actionNotice = `Preview opened on port ${previewPort}. The session expires in ${session.expires_in} seconds.`;
+			} else {
+				actionNotice = 'Your browser blocked the new tab. Use the preview link below.';
+			}
+		} catch (cause) {
+			popup?.close();
+			actionError = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			setBusy(id);
+		}
+	}
+
+	function openIssuedPreview() {
+		if (previewLink) window.open(previewLink, '_blank', 'noopener,noreferrer');
+	}
+
+	onMount(() => {
+		void initialize();
+		const interval = window.setInterval(() => void refreshMachines(true), 10_000);
+		return () => {
+			window.clearInterval(interval);
+			disconnectConnection();
+		};
+	});
+</script>
+
+<div class="flex flex-wrap items-center justify-between gap-4">
+	<div>
+		<h1 class="text-xl font-semibold">Machines</h1>
+		<p class="mt-1 text-sm text-ink-muted">
+			Launch and operate isolated computers in the selected project.
+		</p>
+	</div>
+	<button
+		class="text-xs text-ink-muted hover:text-ink disabled:opacity-50"
+		disabled={loading || refreshInFlight}
+		onclick={() => void refreshMachines()}>Refresh</button
+	>
+</div>
+
+<form
+	class="mt-6 grid gap-3 rounded-geist border border-line bg-surface p-5 sm:grid-cols-2 lg:grid-cols-6"
+	onsubmit={(event) => {
+		event.preventDefault();
+		void launch();
+	}}
+>
+	<label class="text-xs text-ink-muted sm:col-span-2"
+		>Project
+		<select
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+			value={projectId}
+			disabled={launching}
+			onchange={(event) => void changeProject(event.currentTarget.value)}
+		>
+			{#each projects as project (project.id)}<option value={project.id}>{project.name}</option
+				>{/each}
+		</select>
+	</label>
+	<label class="text-xs text-ink-muted sm:col-span-2"
+		>Template
+		<input
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 font-mono text-sm"
+			bind:value={templateName}
+			required
+		/>
+	</label>
+	<label class="text-xs text-ink-muted lg:col-span-2"
+		>Lifetime (seconds)
+		<input
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+			type="number"
+			min="15"
+			max="86400"
+			bind:value={ttlSeconds}
+			required
+		/>
+	</label>
+	<label class="text-xs text-ink-muted"
+		>vCPUs
+		<input
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+			type="number"
+			min="1"
+			max="4"
+			bind:value={vcpus}
+			required
+		/>
+	</label>
+	<label class="text-xs text-ink-muted sm:col-span-2 lg:col-span-2"
+		>Memory (MiB)
+		<input
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+			type="number"
+			min="128"
+			max="4096"
+			step="128"
+			bind:value={memoryMb}
+			required
+		/>
+	</label>
+	<div class="text-xs text-ink-muted sm:col-span-2">
+		Guest egress: <span class="text-ink">off</span>. Managed public networking remains disabled
+		until hard organization, project, and host-network traffic quotas are enforced.
+	</div>
+	<label class="text-xs text-ink-muted sm:col-span-2 lg:col-span-2"
+		>Disk (MiB)
+		<input
+			class="mt-2 w-full rounded-geist border border-line bg-black px-3 py-2 text-sm"
+			type="number"
+			min="512"
+			max="20480"
+			step="512"
+			bind:value={diskMb}
+			required
+		/>
+	</label>
+	<button
+		class="self-end rounded-geist bg-ink px-3 py-2 text-sm font-semibold text-black disabled:opacity-50"
+		disabled={!projectId || launching}>{launching ? 'Launching…' : 'Launch machine'}</button
+	>
+</form>
+
+{#if loadError}<p
+		class="mt-4 rounded-geist border border-red-900/50 bg-red-950/20 p-3 text-sm text-red-300"
+	>
+		{loadError}
+	</p>{/if}
+{#if actionError}<p
+		class="mt-4 rounded-geist border border-red-900/50 bg-red-950/20 p-3 text-sm text-red-300"
+		aria-live="polite"
+	>
+		{actionError}
+	</p>{/if}
+{#if actionNotice}<p
+		class="mt-4 rounded-geist border border-line bg-surface p-3 text-sm text-ink-muted"
+		aria-live="polite"
+	>
+		{actionNotice}
+	</p>{/if}
+{#if previewLink}
+	<button class="mt-3 text-sm font-semibold text-ink underline" onclick={openIssuedPreview}
+		>Open preview</button
+	>
+{/if}
+
+<div class="mt-6 overflow-x-auto rounded-geist border border-line">
+	<table class="w-full text-left text-sm">
+		<thead class="bg-surface text-xs text-ink-muted"
+			><tr
+				><th class="p-3">Machine</th><th class="p-3">State</th><th class="p-3">Expires</th><th
+					class="p-3"
+				></th></tr
+			></thead
+		>
+		<tbody>
+			{#each machines as machine (machine.id)}
+				<tr class="border-t border-line {selectedMachineId === machine.id ? 'bg-surface/60' : ''}">
+					<td class="p-3">
+						<button
+							class="text-left"
+							onclick={() => {
+								disconnectConnection();
+								selectedMachineId = machine.id;
+								execution = undefined;
+								clearActionFeedback();
+							}}
+						>
+							<span class="block font-mono text-xs text-ink">{machine.id}</span>
+							<span class="mt-1 block text-xs text-ink-faint"
+								>{machine.template ?? 'custom'} · {machine.region} · network {machine.network_policy
+									?.mode ?? 'off'}</span
+							>
+						</button>
+					</td>
+					<td class="p-3"
+						><span
+							class={machine.ready
+								? 'text-green-300'
+								: machine.state === 'failed' || machine.state === 'lost'
+									? 'text-red-300'
+									: ''}>{machine.ready ? 'ready' : machine.state}</span
+						></td
+					>
+					<td class="p-3 text-xs text-ink-muted">{formatExpiry(machine.expires_at)}</td>
+					<td class="p-3 text-right">
+						{#if pendingDestroyId === machine.id}
+							<span class="inline-flex items-center gap-2">
+								<button
+									class="text-xs font-semibold text-red-300 hover:text-red-200 disabled:opacity-50"
+									disabled={isBusy(machine.id)}
+									onclick={() => void destroy(machine.id)}>Confirm stop</button
+								>
+								<button
+									class="text-xs text-ink-muted hover:text-ink"
+									onclick={() => {
+										pendingDestroyId = '';
+									}}>Cancel</button
+								>
+							</span>
+						{:else if !isTerminal(machine)}
+							<button
+								class="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
+								disabled={isBusy(machine.id)}
+								onclick={() => {
+									pendingDestroyId = machine.id;
+								}}>Stop</button
+							>
+						{/if}
+					</td>
+				</tr>
+			{:else}
+				<tr
+					><td class="p-5 text-ink-muted" colspan="4"
+						>{loading
+							? 'Loading machines…'
+							: projectId
+								? 'No machines in this project.'
+								: 'Create a project before launching a machine.'}</td
+					></tr
+				>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+{#if selectedMachine}
+	{@const machine = selectedMachine}
+	<section class="mt-6 rounded-geist border border-line bg-surface p-5">
+		<div class="flex flex-wrap items-start justify-between gap-3">
+			<div>
+				<h2 class="font-semibold">Machine tools</h2>
+				<p class="mt-1 font-mono text-xs text-ink-faint">{machine.id}</p>
+			</div>
+			{#if busy[machine.id]}<span class="text-xs text-ink-muted">{busy[machine.id]}</span>{/if}
+		</div>
+		{#if machine.failure_reason}<p class="mt-4 text-sm text-red-300">
+				{machine.failure_reason}
+			</p>{/if}
+		<div class="mt-5 grid gap-6 lg:grid-cols-3">
+			<div>
+				<h3 class="text-sm font-semibold">Lifetime</h3>
+				<p class="mt-1 text-xs text-ink-muted">Expires {formatExpiry(machine.expires_at)}</p>
+				<form
+					class="mt-3 flex gap-2"
+					onsubmit={(event) => {
+						event.preventDefault();
+						void extend(machine.id);
+					}}
+				>
+					<label class="sr-only" for="extension-seconds">Extension seconds</label>
+					<input
+						id="extension-seconds"
+						class="min-w-0 flex-1 rounded-geist border border-line bg-black px-3 py-2 text-sm"
+						type="number"
+						min="15"
+						max="86400"
+						bind:value={extensionSeconds}
+						required
+					/>
+					<button
+						class="rounded-geist border border-line px-3 py-2 text-sm font-semibold disabled:opacity-50"
+						disabled={isBusy(machine.id) || isTerminal(machine)}>Extend</button
+					>
+				</form>
+			</div>
+			<div>
+				<h3 class="text-sm font-semibold">Fork</h3>
+				<p class="mt-1 text-xs text-ink-muted">Batch forks are all-ready or cleaned up together.</p>
+				<form
+					class="mt-3 flex gap-2"
+					onsubmit={(event) => {
+						event.preventDefault();
+						void fork(machine.id);
+					}}
+				>
+					<label class="sr-only" for="fork-count">Fork count</label>
+					<input
+						id="fork-count"
+						class="w-24 rounded-geist border border-line bg-black px-3 py-2 text-sm"
+						type="number"
+						min="1"
+						max="8"
+						bind:value={forkCount}
+						required
+					/>
+					<button
+						class="rounded-geist border border-line px-3 py-2 text-sm font-semibold disabled:opacity-50"
+						disabled={!machine.ready || isBusy(machine.id)}>Fork</button
+					>
+				</form>
+			</div>
+			<div>
+				<h3 class="text-sm font-semibold">Connections</h3>
+				<p class="mt-1 text-xs text-ink-muted">
+					Sessions are capability-scoped and expire after five minutes.
+				</p>
+				<div class="mt-3 flex flex-wrap gap-2">
+					<button
+						class="rounded-geist border border-line px-3 py-2 text-xs font-semibold disabled:opacity-50"
+						disabled={!machine.ready || isBusy(machine.id)}
+						onclick={() => void connectSession(machine.id, 'tty')}>Open TTY</button
+					>
+					<button
+						class="rounded-geist border border-line px-3 py-2 text-xs font-semibold disabled:opacity-50"
+						disabled={!machine.ready || isBusy(machine.id)}
+						onclick={() => void connectSession(machine.id, 'vnc')}>Open desktop</button
+					>
+					{#if connectionKind}<button
+							class="rounded-geist border border-line px-3 py-2 text-xs text-ink-muted hover:text-ink"
+							onclick={disconnectConnection}>Disconnect</button
+						>{/if}
+				</div>
+				<form
+					class="mt-2 flex gap-2"
+					onsubmit={(event) => {
+						event.preventDefault();
+						void openPreview(machine.id);
+					}}
+				>
+					<label class="sr-only" for="preview-port">Preview port</label>
+					<input
+						id="preview-port"
+						class="w-28 rounded-geist border border-line bg-black px-3 py-2 text-sm"
+						type="number"
+						min="1"
+						max="65535"
+						bind:value={previewPort}
+						required
+					/>
+					<button
+						class="rounded-geist border border-line px-3 py-2 text-xs font-semibold disabled:opacity-50"
+						disabled={!machine.ready || isBusy(machine.id)}>Open preview</button
+					>
+				</form>
+			</div>
+		</div>
+		{#if connectionKind}
+			<div class="mt-6 overflow-hidden rounded-geist border border-line bg-black">
+				<div
+					class="flex items-center justify-between border-b border-line px-3 py-2 text-xs text-ink-muted"
+				>
+					<span>{connectionKind === 'tty' ? 'Terminal' : 'Desktop'}</span><span
+						>{connectionStatus}</span
+					>
+				</div>
+				{#if connectionKind === 'tty'}
+					<div class="h-96 p-2" bind:this={terminalHost}></div>
+				{:else}
+					<div class="h-[32rem] overflow-hidden" bind:this={vncScreen}></div>
+				{/if}
+			</div>
+		{/if}
+		<div class="mt-6 border-t border-line pt-5">
+			<h3 class="text-sm font-semibold">Execute a command</h3>
+			<form
+				class="mt-3 grid gap-2"
+				onsubmit={(event) => {
+					event.preventDefault();
+					void exec(machine.id);
+				}}
+			>
+				<textarea
+					class="min-h-20 rounded-geist border border-line bg-black px-3 py-2 font-mono text-sm"
+					bind:value={command}
+					maxlength="65536"
+					spellcheck="false"
+					required></textarea>
+				<button
+					class="justify-self-start rounded-geist bg-ink px-3 py-2 text-sm font-semibold text-black disabled:opacity-50"
+					disabled={!machine.ready || isBusy(machine.id)}>Run command</button
+				>
+			</form>
+			{#if execution}
+				<div class="mt-4 overflow-hidden rounded-geist border border-line bg-black">
+					<div
+						class="flex flex-wrap justify-between gap-2 border-b border-line px-3 py-2 text-xs text-ink-muted"
+					>
+						<span>Exit {execution.exit_code ?? '—'}{execution.timed_out ? ' · timed out' : ''}</span
+						><span>{execution.duration_ms} ms</span>
+					</div>
+					{#if execution.stdout}<pre
+							class="max-h-80 overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-ink">{execution.stdout}</pre>{/if}
+					{#if execution.stderr}<pre
+							class="max-h-80 overflow-auto whitespace-pre-wrap border-t border-line p-3 font-mono text-xs text-red-200">{execution.stderr}</pre>{/if}
+					{#if !execution.stdout && !execution.stderr}<p class="p-3 text-xs text-ink-faint">
+							Command produced no output.
+						</p>{/if}
+				</div>
+			{/if}
+		</div>
+	</section>
+{/if}

--- a/apps/web/src/routes/dashboard/machines/+page.svelte
+++ b/apps/web/src/routes/dashboard/machines/+page.svelte
@@ -371,7 +371,10 @@
 		const requestedPort = previewPort;
 		try {
 			const session = await issueSession(id, 'preview');
-			if (generation !== previewGeneration) {
+			// Abandon the preview if the user switched projects (previewGeneration) or
+			// selected a different machine. Connecting a TTY/VNC session leaves the
+			// selection unchanged, so a valid pending preview is not cancelled.
+			if (generation !== previewGeneration || id !== selectedMachineId) {
 				popup?.close();
 				return;
 			}

--- a/apps/web/src/routes/dashboard/projects/+page.svelte
+++ b/apps/web/src/routes/dashboard/projects/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dashboardApi } from '$lib/nehemiah-client';
+
+	type Project = {
+		id: string;
+		name: string;
+		slug: string;
+		max_machines: number;
+		max_vcpus: number;
+		max_memory_mb: number;
+		max_disk_mb: number;
+		max_storage_mb: number;
+	};
+	let projects = $state<Project[]>([]);
+	let name = $state('');
+	let slug = $state('');
+	let error = $state('');
+
+	async function load() {
+		try {
+			projects = (await dashboardApi<{ projects: Project[] }>('/v1/projects')).projects;
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	async function create() {
+		error = '';
+		try {
+			await dashboardApi('/v1/projects', { method: 'POST', body: JSON.stringify({ name, slug }) });
+			name = '';
+			slug = '';
+			await load();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	onMount(() => void load());
+</script>
+
+<h1 class="text-xl font-semibold">Projects</h1>
+<form
+	class="mt-6 grid max-w-xl gap-3 rounded-geist border border-line bg-surface p-5 sm:grid-cols-2"
+	onsubmit={(event) => {
+		event.preventDefault();
+		void create();
+	}}
+>
+	<input
+		class="rounded-geist border border-line bg-black px-3 py-2 text-sm"
+		placeholder="Project name"
+		bind:value={name}
+		required
+	/>
+	<input
+		class="rounded-geist border border-line bg-black px-3 py-2 font-mono text-sm"
+		placeholder="project-slug"
+		bind:value={slug}
+		pattern={'[a-z0-9][a-z0-9-]{1,62}'}
+		required
+	/>
+	<button class="rounded-geist bg-ink px-3 py-2 text-sm font-semibold text-black sm:col-span-2"
+		>Create project</button
+	>
+</form>
+{#if error}<p class="mt-4 text-sm text-red-300">{error}</p>{/if}
+<div class="mt-6 divide-y divide-line rounded-geist border border-line">
+	{#each projects as project (project.id)}
+		<div class="flex flex-wrap items-center justify-between gap-4 p-4">
+			<div>
+				<div class="font-medium">{project.name}</div>
+				<div class="font-mono text-xs text-ink-faint">{project.id}</div>
+			</div>
+			<div class="grid grid-cols-2 gap-x-5 gap-y-1 text-xs text-ink-muted sm:grid-cols-4">
+				<span>{project.max_machines} machines</span>
+				<span>{project.max_vcpus} vCPUs</span>
+				<span>{project.max_memory_mb.toLocaleString()} MiB memory</span>
+				<span>{project.max_disk_mb.toLocaleString()} MiB machine disk</span>
+				<span>{project.max_storage_mb.toLocaleString()} MiB volume storage</span>
+			</div>
+		</div>
+	{:else}<p class="p-4 text-sm text-ink-muted">No projects yet.</p>{/each}
+</div>

--- a/apps/web/src/routes/dashboard/templates/+page.svelte
+++ b/apps/web/src/routes/dashboard/templates/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dashboardApi } from '$lib/nehemiah-client';
+
+	type Project = { id: string; name: string };
+	type Template = {
+		id: string;
+		project_id: string;
+		name: string;
+		version: string;
+		checksum: string;
+		size_bytes: number;
+		manifest?: { architecture?: string };
+	};
+
+	let projects = $state<Project[]>([]);
+	let templates = $state<Template[]>([]);
+	let projectId = $state('');
+	let deletingId = $state('');
+	let loading = $state(false);
+	let error = $state('');
+
+	async function loadProjectResources() {
+		if (!projectId) {
+			templates = [];
+			return;
+		}
+		const project = encodeURIComponent(projectId);
+		const templateResult = await dashboardApi<{ templates: Template[] }>(
+			`/v1/templates?project_id=${project}`
+		);
+		templates = templateResult.templates;
+	}
+
+	async function load() {
+		loading = true;
+		error = '';
+		try {
+			projects = (await dashboardApi<{ projects: Project[] }>('/v1/projects')).projects;
+			if (!projects.some((project) => project.id === projectId)) projectId = projects[0]?.id ?? '';
+			await loadProjectResources();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function changeProject(id: string) {
+		projectId = id;
+		error = '';
+		try {
+			await loadProjectResources();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	}
+
+	async function remove(template: Template) {
+		if (deletingId || !confirm(`Delete immutable template ${template.name}@${template.version}?`))
+			return;
+		deletingId = template.id;
+		error = '';
+		try {
+			await dashboardApi(
+				`/v1/templates/${encodeURIComponent(template.id)}?project_id=${encodeURIComponent(projectId)}`,
+				{ method: 'DELETE' }
+			);
+			await loadProjectResources();
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		} finally {
+			deletingId = '';
+		}
+	}
+
+	onMount(() => void load());
+</script>
+
+<h1 class="text-xl font-semibold">Templates</h1>
+<p class="mt-2 text-sm text-ink-muted">
+	Inspect managed template records available to this project.
+</p>
+
+<section class="mt-6 max-w-2xl rounded-geist border border-line bg-surface p-5">
+	<p class="text-sm text-ink-muted">
+		Managed custom-template publication is disabled for the private beta until aggregate storage
+		quotas and durable object/replica eviction are enforced. Built-in templates remain available
+		when launching a machine.
+	</p>
+	<label class="grid gap-1 text-xs text-ink-muted">
+		Project
+		<select
+			class="rounded-geist border border-line bg-black px-3 py-2 text-sm text-ink"
+			value={projectId}
+			onchange={(event) => void changeProject(event.currentTarget.value)}
+			required
+		>
+			{#each projects as project (project.id)}<option value={project.id}>{project.name}</option
+				>{/each}
+		</select>
+	</label>
+</section>
+
+{#if error}<p class="mt-5 rounded-geist border border-line p-4 text-sm text-red-300">
+		{error}
+	</p>{/if}
+
+<div class="mt-6 divide-y divide-line rounded-geist border border-line">
+	{#each templates as template (template.id)}
+		<div class="flex flex-wrap items-center justify-between gap-4 p-4">
+			<div>
+				<div class="font-medium">{template.name}@{template.version}</div>
+				<div class="font-mono text-xs text-ink-faint">
+					{template.id} · {template.manifest?.architecture ?? 'unknown arch'} · {template.size_bytes.toLocaleString()}
+					bytes
+				</div>
+				<div class="mt-1 max-w-xl truncate font-mono text-[11px] text-ink-faint">
+					sha256:{template.checksum}
+				</div>
+			</div>
+			<button
+				class="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
+				disabled={deletingId === template.id}
+				onclick={() => void remove(template)}
+				>{deletingId === template.id ? 'Deleting…' : 'Delete'}</button
+			>
+		</div>
+	{:else}
+		<p class="p-4 text-sm text-ink-muted">
+			{loading ? 'Loading templates…' : 'No templates in this project.'}
+		</p>
+	{/each}
+</div>

--- a/apps/web/src/routes/dashboard/usage/+page.svelte
+++ b/apps/web/src/routes/dashboard/usage/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dashboardApi } from '$lib/nehemiah-client';
+
+	type Usage = { usage_date: string; dimension: string; quantity: string; project_id: string };
+	let usage = $state<Usage[]>([]);
+	let plan = $state('private_beta');
+	let spendCapCents = $state<number>();
+	let delinquentAt = $state<string>();
+	let error = $state('');
+	onMount(
+		() =>
+			void dashboardApi<{
+				account: { plan: string; spend_cap_cents?: number; delinquent_at?: string };
+				usage: Usage[];
+			}>('/v1/billing/usage')
+				.then((result) => {
+					plan = result.account.plan;
+					spendCapCents = result.account.spend_cap_cents;
+					delinquentAt = result.account.delinquent_at;
+					usage = result.usage;
+				})
+				.catch((cause) => {
+					error = cause instanceof Error ? cause.message : String(cause);
+				})
+	);
+</script>
+
+<h1 class="text-xl font-semibold">Usage</h1>
+<p class="mt-2 text-sm text-ink-muted">
+	Plan: {plan}. Private-beta metering runs in shadow mode
+	{spendCapCents === undefined ? '' : ` with a $${(spendCapCents / 100).toFixed(2)} spend cap`}.
+</p>
+{#if delinquentAt}<p
+		class="mt-3 rounded-geist border border-red-900/50 bg-red-950/20 p-3 text-sm text-red-200"
+	>
+		Billing became delinquent on {new Date(delinquentAt).toLocaleString()}. New placements may be
+		blocked.
+	</p>{/if}
+{#if error}<p class="mt-4 text-sm text-red-300">{error}</p>{/if}
+<div class="mt-6 overflow-x-auto rounded-geist border border-line">
+	<table class="w-full text-left text-sm">
+		<thead class="bg-surface text-xs text-ink-muted"
+			><tr
+				><th class="p-3">Date</th><th class="p-3">Project</th><th class="p-3">Dimension</th><th
+					class="p-3 text-right">Quantity</th
+				></tr
+			></thead
+		><tbody
+			>{#each usage as row (`${row.usage_date}:${row.project_id}:${row.dimension}`)}<tr
+					class="border-t border-line"
+					><td class="p-3">{row.usage_date}</td><td class="p-3 font-mono text-xs"
+						>{row.project_id}</td
+					><td class="p-3">{row.dimension}</td><td class="p-3 text-right font-mono"
+						>{row.quantity}</td
+					></tr
+				>{:else}<tr><td colspan="4" class="p-5 text-ink-muted">No metered usage yet.</td></tr
+				>{/each}</tbody
+		>
+	</table>
+</div>

--- a/apps/web/src/routes/dashboard/volumes/+page.svelte
+++ b/apps/web/src/routes/dashboard/volumes/+page.svelte
@@ -1,0 +1,14 @@
+<svelte:head><title>Volumes · Nehemiah</title></svelte:head>
+
+<h1 class="text-xl font-semibold">Volumes</h1>
+<div class="mt-6 max-w-2xl rounded-geist border border-line bg-surface p-6">
+	<h2 class="font-medium">Not available in the managed private beta</h2>
+	<p class="mt-2 text-sm leading-6 text-ink-muted">
+		Managed volume creation and object transfers are disabled until the service enforces durable
+		volume and revision-count quotas together with global organization and project transfer limits.
+	</p>
+	<p class="mt-3 text-sm leading-6 text-ink-muted">
+		Machine disks remain ephemeral and are destroyed with the machine. Use an external reviewed
+		storage workflow for data that must persist.
+	</p>
+</div>

--- a/apps/web/src/routes/docs/+page.svelte
+++ b/apps/web/src/routes/docs/+page.svelte
@@ -83,7 +83,7 @@ curl -s -X POST ${API}/v1/machines \\
 	<div class="mt-3 overflow-x-auto rounded-geist border border-line">
 		<table class="w-full border-collapse font-mono text-[12px]">
 			<tbody class="text-ink-muted">
-				{#each [['/v1/machines/{id}/tty', 'Serial console — bytes ⇄ the guest /dev/ttyS0'], ['/v1/machines/{id}/vnc', 'RFB/VNC framebuffer for desktop machines'], ['/v1/machines/{id}/agent?goal=…', 'Computer-use agent — drives the screen; streams narration JSON'], ['/v1/machines/{id}/shell-agent?goal=…', 'Terminal agent — writes + runs code; streams narration JSON']] as row (row[0])}
+				{#each [['/v1/machines/{id}/tty', 'Interactive guest-agent PTY — binary frames both ways'], ['/v1/machines/{id}/vnc', 'RFB/VNC framebuffer for desktop machines'], ['/v1/machines/{id}/agent', 'Local/self-hosted computer-use agent; managed cloud returns not_supported'], ['/v1/machines/{id}/shell-agent', 'Local/self-hosted terminal agent; managed cloud returns not_supported']] as row (row[0])}
 					<tr class="border-b border-line last:border-0">
 						<td class="px-3 py-2 align-top whitespace-nowrap text-ink">{row[0]}</td>
 						<td class="px-3 py-2 align-top text-ink-faint">{row[1]}</td>
@@ -128,26 +128,10 @@ curl -s -X POST ${API}/v1/machines \\
 
 	<h2 class="mt-12 text-[15px] font-semibold text-ink">Storage</h2>
 	<p class="mt-2 text-[13px] leading-relaxed text-ink-muted">
-		Persistent volumes (S3-backed) that outlive a machine. Create one, <code class="text-ink"
-			>save</code
-		>
-		a machine's /root into it, then restore it into a fresh machine by passing its id as
-		<code class="text-ink">volume</code> on launch. Volumes are addressed by an unguessable id and garbage-collected
-		on a TTL.
+		Managed volumes are disabled in the private beta until durable volume/revision-count quotas,
+		global transfer admission, and the machine attach/save path are complete. Machine disks are
+		ephemeral.
 	</p>
-	<div class="mt-3 overflow-x-auto rounded-geist border border-line">
-		<table class="w-full border-collapse font-mono text-[12px]">
-			<tbody class="text-ink-muted">
-				{#each [['POST', '/v1/volumes', 'Create a volume. Body: {ttl_seconds}'], ['GET', '/v1/volumes/{id}', 'Metadata + usage'], ['DELETE', '/v1/volumes/{id}', 'Delete a volume'], ['GET', '/v1/volumes/{id}/files', 'List files'], ['PUT', '/v1/volumes/{id}/file?path=…', 'Upload a file'], ['GET', '/v1/volumes/{id}/file?path=…', 'Download a file'], ['POST', '/v1/machines/{id}/save?volume=…', "Save a machine's /root into a volume"]] as row (row[1] + row[0])}
-					<tr class="border-b border-line last:border-0">
-						<td class="w-16 px-3 py-2 align-top text-accent">{row[0]}</td>
-						<td class="px-3 py-2 align-top whitespace-nowrap text-ink">{row[1]}</td>
-						<td class="px-3 py-2 align-top text-ink-faint">{row[2]}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</div>
 	<p class="mt-3 text-[13px] leading-relaxed text-ink-muted">
 		Attach on launch: <code class="text-ink">POST /v1/machines</code> with
 		<code class="text-ink">{'{"volume":"vol-…"}'}</code> restores the volume into /root first.
@@ -214,11 +198,12 @@ Effect.runPromise(
 }`)}
 	</div>
 	<p class="mt-3 text-[13px] leading-relaxed text-ink-muted">
-		Tools: <code class="text-ink">launch_computer</code>,
-		<code class="text-ink">run_task</code> (plain-English task → an agent writes + runs the code,
-		returns a live URL), <code class="text-ink">screenshot</code>,
-		<code class="text-ink">preview_url</code>, <code class="text-ink">fork_computer</code>,
-		<code class="text-ink">stop_computer</code>.
+		Cloud tools: <code class="text-ink">launch_computer</code>,
+		<code class="text-ink">run_command</code>, <code class="text-ink">preview_url</code>,
+		<code class="text-ink">fork_computer</code>, and <code class="text-ink">stop_computer</code>.
+		Host-local <code class="text-ink">run_task</code> and <code class="text-ink">screenshot</code>
+		are advertised only for local/self-hosted targets; managed callers can run their own agent inside
+		the guest.
 	</p>
 
 	<div class="mt-16 border-t border-line pt-6">

--- a/apps/web/src/routes/status/+page.server.ts
+++ b/apps/web/src/routes/status/+page.server.ts
@@ -1,0 +1,13 @@
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { collectPublicStatus, PUBLIC_STATUS_CACHE_CONTROL } from '$lib/server/public-status';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ setHeaders }) => {
+	setHeaders({ 'cache-control': PUBLIC_STATUS_CACHE_CONTROL });
+	return collectPublicStatus({
+		controlPlaneUrl: env.STATUS_CONTROL_PLANE_URL,
+		gatewayUrl: env.STATUS_GATEWAY_URL,
+		production: !dev
+	});
+};

--- a/apps/web/src/routes/status/+page.svelte
+++ b/apps/web/src/routes/status/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+
+	const label = (status: string): string =>
+		({
+			operational: 'Operational',
+			degraded: 'Degraded',
+			outage: 'Service outage',
+			unknown: 'Status unknown'
+		})[status] ?? 'Status unknown';
+</script>
+
+<svelte:head>
+	<title>Status · Nehemiah</title>
+	<meta
+		name="description"
+		content="Coarse, current health signals for the Boring Computers control plane and gateway."
+	/>
+</svelte:head>
+
+<main class="mx-auto min-h-screen max-w-2xl px-5 pt-24 pb-24 text-ink">
+	<header class="border-b border-line pb-8">
+		<p class="font-mono text-[11px] tracking-wide text-ink-faint uppercase">Public status</p>
+		<div class="mt-3 flex flex-wrap items-center justify-between gap-4">
+			<h1 class="text-[28px] font-semibold tracking-[-0.03em]">{label(data.status)}</h1>
+			<div class="flex items-center gap-2 font-mono text-[12px]">
+				{#if data.status === 'operational'}
+					<span class="h-2.5 w-2.5 rounded-full bg-success" aria-hidden="true"></span>
+				{:else if data.status === 'outage'}
+					<span class="h-2.5 w-2.5 rounded-full bg-danger" aria-hidden="true"></span>
+				{:else if data.status === 'degraded'}
+					<span class="h-2.5 w-2.5 rounded-full bg-amber-400" aria-hidden="true"></span>
+				{:else}
+					<span class="h-2.5 w-2.5 rounded-full bg-ink-faint" aria-hidden="true"></span>
+				{/if}
+				<span class="text-ink-muted">{label(data.status)}</span>
+			</div>
+		</div>
+		<p class="mt-3 text-[13px] leading-relaxed text-ink-muted">
+			Checked at <time class="font-mono text-ink" datetime={data.checked_at}>{data.checked_at}</time
+			>.
+		</p>
+	</header>
+
+	<section class="py-8" aria-labelledby="components-heading">
+		<h2
+			id="components-heading"
+			class="text-[13px] font-semibold tracking-wide text-ink-faint uppercase"
+		>
+			Components
+		</h2>
+		<div class="mt-4 overflow-hidden rounded-geist-lg border border-line bg-surface">
+			<div class="flex items-center justify-between gap-4 border-b border-line px-5 py-4">
+				<div>
+					<h3 class="text-sm font-semibold">Control plane</h3>
+					<p class="mt-1 text-xs text-ink-muted">API liveness and database-backed readiness</p>
+				</div>
+				<span class="font-mono text-xs text-ink-muted">{label(data.components.control_plane)}</span>
+			</div>
+			<div class="flex items-center justify-between gap-4 px-5 py-4">
+				<div>
+					<h3 class="text-sm font-semibold">Gateway</h3>
+					<p class="mt-1 text-xs text-ink-muted">Public connection edge health</p>
+				</div>
+				<span class="font-mono text-xs text-ink-muted">{label(data.components.gateway)}</span>
+			</div>
+		</div>
+	</section>
+
+	<section class="border-t border-line py-8" aria-labelledby="meaning-heading">
+		<h2 id="meaning-heading" class="text-[15px] font-semibold">What this check means</h2>
+		<p class="mt-2 text-[13px] leading-relaxed text-ink-muted">
+			This is a bounded, point-in-time reachability and readiness check. It is not a complete
+			end-to-end test, an incident history, an availability guarantee, or a measurement of the
+			service SLO. An unknown result means the public checker could not safely establish health; it
+			does not prove an outage.
+		</p>
+	</section>
+
+	<section class="border-t border-line py-8" aria-labelledby="incident-heading">
+		<h2 id="incident-heading" class="text-[15px] font-semibold">If you are seeing an incident</h2>
+		<ul class="mt-3 list-disc space-y-2 pl-5 text-[13px] leading-relaxed text-ink-muted">
+			<li>Retry only operations that are documented as safe or idempotent.</li>
+			<li>Preserve the UTC time and public request ID shown by your client.</li>
+			<li>
+				Never post API keys, access or refresh credentials, terminal contents, or private IDs.
+			</li>
+		</ul>
+		<div class="mt-5 flex flex-wrap gap-4 font-mono text-xs">
+			<a class="text-accent hover:underline" href={resolve('/support')}>Support guidance</a>
+			<a class="text-ink-muted hover:text-ink" href={resolve('/docs')}>Public documentation</a>
+		</div>
+	</section>
+</main>

--- a/apps/web/src/routes/support/+page.server.ts
+++ b/apps/web/src/routes/support/+page.server.ts
@@ -1,0 +1,14 @@
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/public';
+import { publicSupportConfig } from '$lib/public-support';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = ({ setHeaders }) => {
+	setHeaders({
+		'cache-control': 'public, max-age=30, s-maxage=30, stale-while-revalidate=60'
+	});
+	return publicSupportConfig(
+		{ url: env.PUBLIC_SUPPORT_URL, email: env.PUBLIC_SUPPORT_EMAIL },
+		!dev
+	);
+};

--- a/apps/web/src/routes/support/+page.svelte
+++ b/apps/web/src/routes/support/+page.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>Support · Nehemiah</title>
+	<meta
+		name="description"
+		content="Public support guidance for Boring Computers and self-hosted Nehemiah deployments."
+	/>
+</svelte:head>
+
+<main class="mx-auto min-h-screen max-w-2xl px-5 pt-24 pb-24 text-ink">
+	<header class="border-b border-line pb-8">
+		<p class="font-mono text-[11px] tracking-wide text-ink-faint uppercase">Public support</p>
+		<h1 class="mt-3 text-[28px] font-semibold tracking-[-0.03em]">Get help</h1>
+		<p class="mt-3 max-w-xl text-[13px] leading-relaxed text-ink-muted">
+			Start with the public documentation and current coarse service status. This page intentionally
+			does not expose private operations contacts, escalation policy, infrastructure names, or
+			internal runbooks.
+		</p>
+	</header>
+
+	<section class="py-8" aria-labelledby="contact-heading">
+		<h2 id="contact-heading" class="text-[15px] font-semibold">Contact and documentation</h2>
+		<div class="mt-4 grid gap-3 sm:grid-cols-2">
+			<a
+				class="rounded-geist-lg border border-line bg-surface p-5 transition-colors hover:border-ink-faint"
+				href={resolve('/docs')}
+			>
+				<div class="text-sm font-semibold">Public docs</div>
+				<div class="mt-1 text-xs leading-relaxed text-ink-muted">
+					API, CLI, and self-hosting guidance
+				</div>
+			</a>
+			<a
+				class="rounded-geist-lg border border-line bg-surface p-5 transition-colors hover:border-ink-faint"
+				href={resolve('/status')}
+			>
+				<div class="text-sm font-semibold">Service status</div>
+				<div class="mt-1 text-xs leading-relaxed text-ink-muted">
+					Current coarse component health
+				</div>
+			</a>
+			{#if data.url}
+				<a
+					class="rounded-geist-lg border border-line bg-surface p-5 transition-colors hover:border-ink-faint"
+					href={data.url}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<div class="text-sm font-semibold">Support portal ↗</div>
+					<div class="mt-1 text-xs leading-relaxed text-ink-muted">Deployment support channel</div>
+				</a>
+			{/if}
+			{#if data.email}
+				<a
+					class="rounded-geist-lg border border-line bg-surface p-5 transition-colors hover:border-ink-faint"
+					href={`mailto:${data.email}`}
+				>
+					<div class="text-sm font-semibold">Email support</div>
+					<div class="mt-1 break-all font-mono text-xs text-ink-muted">{data.email}</div>
+				</a>
+			{/if}
+		</div>
+		{#if !data.url && !data.email}
+			<p class="mt-4 text-xs leading-relaxed text-ink-faint">
+				This deployment has not published a direct support contact. Self-hosted users should contact
+				the operator who provided their endpoint.
+			</p>
+		{/if}
+	</section>
+
+	<section class="border-t border-line py-8" aria-labelledby="ephemeral-heading">
+		<h2 id="ephemeral-heading" class="text-[15px] font-semibold">
+			Ephemeral machines and host loss
+		</h2>
+		<p class="mt-2 text-[13px] leading-relaxed text-ink-muted">
+			A machine is ephemeral compute. If its physical host is lost, the running VM, memory, and any
+			filesystem changes that were not saved to a durable volume or published template may be
+			unrecoverable. A persistent TTL does not turn local VM state into durable storage. Keep
+			important data on the documented durable storage path and make machine creation safe to retry.
+		</p>
+	</section>
+
+	<section class="border-t border-line py-8" aria-labelledby="report-heading">
+		<h2 id="report-heading" class="text-[15px] font-semibold">When reporting a problem</h2>
+		<ul class="mt-3 list-disc space-y-2 pl-5 text-[13px] leading-relaxed text-ink-muted">
+			<li>
+				Include the UTC time, operation, client version, and public request ID when available.
+			</li>
+			<li>Say whether a retry changed the result and whether durable data is affected.</li>
+			<li>
+				Do not send API keys, session credentials, device codes, or terminal and file contents.
+			</li>
+		</ul>
+	</section>
+</main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,7 +264,8 @@
         "@novnc/novnc": "^1.7.0",
         "@vercel/analytics": "^2.0.1",
         "@xterm/addon-fit": "^0.10.0",
-        "@xterm/xterm": "^5.5.0"
+        "@xterm/xterm": "^5.5.0",
+        "cookie": "0.7.2"
       },
       "devDependencies": {
         "@nehemiah/eslint-config": "*",
@@ -278,7 +279,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
         "@types/node": "^24",
-        "@vitest/browser-playwright": "^4.1.8",
+        "@vitest/browser-playwright": "^4.1.10",
         "eslint": "^10.4.1",
         "playwright": "^1.60.0",
         "prettier": "^3.8.3",
@@ -287,8 +288,331 @@
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
-        "vitest": "^4.1.8",
+        "vitest": "^4.1.10",
         "vitest-browser-svelte": "^2.1.1"
+      }
+    },
+    "apps/web/node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "apps/web/node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "apps/web/node_modules/@vitest/browser-playwright/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@vitest/browser/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "apps/web/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "apps/web/node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "apps/web/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -3846,59 +4170,13 @@
         "node": ">=20"
       }
     },
-    "node_modules/@vitest/browser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
-      "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "magic-string": "^0.30.21",
-        "pngjs": "^7.0.0",
-        "sirv": "^3.0.2",
-        "tinyrainbow": "^3.1.0",
-        "ws": "^8.19.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "4.1.9"
-      }
-    },
-    "node_modules/@vitest/browser-playwright": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.9.tgz",
-      "integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/browser": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "playwright": "*",
-        "vitest": "4.1.9"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
       "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
@@ -3917,6 +4195,7 @@
       "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
@@ -3944,6 +4223,7 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -3954,6 +4234,7 @@
       "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -3967,6 +4248,7 @@
       "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
@@ -3981,6 +4263,7 @@
       "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.9",
         "@vitest/utils": "4.1.9",
@@ -3997,6 +4280,7 @@
       "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -4007,6 +4291,7 @@
       "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
@@ -7835,6 +8120,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",


### PR DESCRIPTION
Part of landing the Nehemiah managed cloud as reviewed slices (rename, docs, guest-agent, nehemiahd, gateway, control plane, clients already on `main`).

**This PR:** the SvelteKit **dashboard and public pages** (`apps/web`) — authenticated organization/project/machine/template/volume/usage/API-key views, device approval, and public status + support pages. Secrets stay server-side (only the Clerk publishable key reaches the browser); the `/dashboard/api` proxy is a bounded pass-through with a strict path allowlist; authz is enforced server-side in the control plane; rendering is XSS-clean.

**Merge note:** the `apps/web` changes were 3-way merged onto `main` so PR #9's countdown-getter change is preserved — `createCountdown` now accepts `number | (() => number)`.

**Self-consistent:** `svelte-check` clean (0 errors/warnings), production build passes, 55 tests pass. Lockfile regenerated (adds Clerk).

**Base:** `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boringcomputers/codesmith/nehemiah/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788991918&installation_model_id=425754&pr_number=21&repository=boringcomputers%2Fnehemiah&return_to=https%3A%2F%2Fgithub.com%2Fboringcomputers%2Fnehemiah%2Fpull%2F21&signature=76d7eebd0c03512880490a7fbc3272e0f6dd1113f94a83db0224239ac1636dbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->